### PR TITLE
ns-migrate 0.21.0

### DIFF
--- a/ns-system/kustomization.yaml
+++ b/ns-system/kustomization.yaml
@@ -68,7 +68,7 @@ images:
   newTag: 0.20.1
 - name: ns-migrate
   newName: ghcr.io/traptitech/ns-migrate
-  newTag: 0.20.1
+  newTag: 0.21.0
 - name: ns-ssgen
   newName: ghcr.io/traptitech/ns-ssgen
   newTag: 0.20.1


### PR DESCRIPTION
スキーマ変更を含み、先にmigrateが必要なため