### PR TITLE
Upgrade k3s to 1.29.1

### DIFF
--- a/system-upgrade/agent-plan.yaml
+++ b/system-upgrade/agent-plan.yaml
@@ -21,4 +21,4 @@ spec:
   upgrade:
     image: rancher/k3s-upgrade
   # renovate:k3s
-  version: "v1.29.0+k3s1"
+  version: "v1.29.1+k3s1"

--- a/system-upgrade/server-plan.yaml
+++ b/system-upgrade/server-plan.yaml
@@ -16,4 +16,4 @@ spec:
   upgrade:
     image: rancher/k3s-upgrade
   # renovate:k3s
-  version: "v1.29.0+k3s1"
+  version: "v1.29.1+k3s1"


### PR DESCRIPTION
ノード追加したらlatest (1.29.1) がインストールされてしまい、なぜかまだprereleaseになっていてrenovateが検知できていないため (忘れてる?)
downgradeしようとして失敗しているため