### PR TITLE
argoのaffinityを設定

### DIFF
--- a/argo/values.yaml
+++ b/argo/values.yaml
@@ -1,3 +1,13 @@
+global:
+  affinity:
+    nodeAffinity:
+      type: soft
+      matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+            - e505.tokyotech.org
+
 server:
   authModes:
     - server


### PR DESCRIPTION
argoにはできるだけe505にいて欲しいので、<https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/README.md>を参考にaffinityを設定した

背景: https://q.trap.jp/messages/a14f44ac-c609-4a0e-95fa-91d4e041b701