### PR TITLE
giteaのmetricsをプライベートネットワークから取得

### DIFF
--- a/monitor/victoria-metrics/config/prometheus.yml
+++ b/monitor/victoria-metrics/config/prometheus.yml
@@ -480,7 +480,7 @@ scrape_configs:
     scheme: https
     static_configs:
       - targets:
-          - git.trap.jp:443
+          - private.s423.tokyotech.org:1101
     tls_config:
       insecure_skip_verify: true
     relabel_configs:


### PR DESCRIPTION
`/metrics`のみプライベートネットワークからは認証を外したため
https://git.trap.jp/SysAd/tokyotech.org/pulls/556