### PR TITLE
[harbor/gc] current tag が nil の時にログを出して処理を続ける

### DIFF
--- a/harbor/gc/source/main.go
+++ b/harbor/gc/source/main.go
@@ -272,7 +272,9 @@ func main() {
 	for repoName, repo := range repos {
 		for tagName, tag := range repo.Tags {
 			if tag.CurrentObject == nil {
-				panic(fmt.Sprintf("%v:%v current tag link is nil", repoName, tagName))
+				log.Warnf("%v:%v current tag link is nil", repoName, tagName)
+				delete(repos[repoName].Tags, tagName)
+				continue
 			}
 			wg.Go(func() {
 				digest := strings.TrimPrefix(string(lo.Must(readObject(tag.CurrentObject.Path))), "sha256:")

--- a/harbor/gc/source/main.go
+++ b/harbor/gc/source/main.go
@@ -5,6 +5,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/samber/lo"
 	"github.com/schollz/progressbar/v3"
 	log "github.com/sirupsen/logrus"
@@ -12,12 +20,6 @@ import (
 	"github.com/sourcegraph/conc/pool"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
-	"os"
-	"os/exec"
-	"regexp"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var (
@@ -205,7 +207,7 @@ func main() {
 			}
 		}
 	}
-	for _, object := range lo.Values(objects) {
+	for _, object := range objects {
 		switch {
 		case uploadsPattern.MatchString(object.Path):
 			m := uploadsPattern.FindStringSubmatch(object.Path)
@@ -219,25 +221,29 @@ func main() {
 			blobs[m[1]] = object
 		case layersPattern.MatchString(object.Path):
 			m := layersPattern.FindStringSubmatch(object.Path)
-			ensureRepoMap(m[1])
-			repos[m[1]].Layers[m[2]] = object
+			repoName, digest := m[1], m[2]
+			ensureRepoMap(repoName)
+			repos[repoName].Layers[digest] = object
 		case revisionsPattern.MatchString(object.Path):
 			m := revisionsPattern.FindStringSubmatch(object.Path)
-			ensureRepoMap(m[1])
-			repos[m[1]].ManifestRevisions[m[2]] = object
+			repoName, digest := m[1], m[2]
+			ensureRepoMap(repoName)
+			repos[repoName].ManifestRevisions[digest] = object
 		case currentTagPattern.MatchString(object.Path):
 			m := currentTagPattern.FindStringSubmatch(object.Path)
-			ensureRepoMap(m[1])
-			ensureTagMap(m[1], m[2])
-			if repos[m[1]].Tags[m[2]].CurrentObject != nil {
+			repoName, tagName := m[1], m[2]
+			ensureRepoMap(repoName)
+			ensureTagMap(repoName, tagName)
+			if repos[repoName].Tags[tagName].CurrentObject != nil {
 				panic(fmt.Sprintf("multiple current object read: %v", object.Path))
 			}
-			repos[m[1]].Tags[m[2]].CurrentObject = object
+			repos[repoName].Tags[tagName].CurrentObject = object
 		case tagPattern.MatchString(object.Path):
 			m := tagPattern.FindStringSubmatch(object.Path)
-			ensureRepoMap(m[1])
-			ensureTagMap(m[1], m[2])
-			repos[m[1]].Tags[m[2]].Objects[m[3]] = object
+			repoName, tagName, digest := m[1], m[2], m[3]
+			ensureRepoMap(repoName)
+			ensureTagMap(repoName, tagName)
+			repos[repoName].Tags[tagName].Objects[digest] = object
 		default:
 			panic(fmt.Sprintf("unknown object path pattern: %v", object.Path))
 		}
@@ -369,7 +375,7 @@ func main() {
 		log.Infof("%d unreachable tags found", len(unreachableTags))
 		log.Infof("%d unreachable tag objects found", len(unreachableTagObjects))
 
-		deletionCandidates := concat(deletableUploads, unreachableBlobs, unreachableLayers, unreachableRevisions, unreachableTags, unreachableTagObjects)
+		deletionCandidates := slices.Concat(deletableUploads, unreachableBlobs, unreachableLayers, unreachableRevisions, unreachableTags, unreachableTagObjects)
 		deleteObjectOlderThan := time.Now().Add(-time.Hour) // Do not delete objects that have uploads in progress
 		objectsToDelete := lo.Filter(deletionCandidates, func(object *Object, _ int) bool { return object.Modified.Before(deleteObjectOlderThan) })
 		log.Infof("%d objects are candidates for deletion; of which, %d objects are old enough and safe to delete", len(deletionCandidates), len(objectsToDelete))
@@ -397,12 +403,4 @@ func main() {
 			}
 		}
 	}
-}
-
-func concat[T any](s ...[]T) []T {
-	var res []T
-	for _, ss := range s {
-		res = append(res, ss...)
-	}
-	return res
 }


### PR DESCRIPTION
```
time="2024-09-29T19:03:32Z" level=info msg="Reading current tag links ..."
panic: ns-apps/a48e7f770171112648c846:544c06eda2a3c4465b0c99 current tag link is nil
goroutine 1 [running]:
main.main()
	/scripts/main.go:269 +0x32cb
```
panic するとほかの処理ができなくなるため、ログだけ出して処理を続けるようにする
この変更を入れた後のログなどを見て、current tag が nil になっている原因を調査する