### PR TITLE
lokiの保持設定の変更

### DIFF
--- a/monitor/loki/config/config.yaml
+++ b/monitor/loki/config/config.yaml
@@ -33,6 +33,7 @@ limits_config:
   reject_old_samples_max_age: 168h
   split_queries_by_interval: 15m
   allow_structured_metadata: false # TODO: Delete after tsdb store is in effect (after 2024-04-10 00:00:00 UTC)
+  retention_period: 90d
 
 memberlist:
   join_members:
@@ -73,7 +74,11 @@ server:
   grpc_listen_port: 9095
   http_listen_port: 3100
 
-table_manager:
-  retention_deletes_enabled: true
-  # 7 days
-  retention_period: 168h
+compactor:
+  retention_enabled: true
+  delete_request_store: filesystem
+
+#table_manager:
+#  retention_deletes_enabled: true
+#  # 7 days
+#  retention_period: 168h


### PR DESCRIPTION
- table_managerを無効化
- Compactorをfilesystemに対して設定
- Compactorの保持時間を90日に

ローカルのテストでは、以前のログにアクセスできなくなることが確認できました。（容量の減少は見ていなくて確認できていません🙇）