### PR TITLE
e505にあるPodを、停止するか他のNodeに移動する

### DIFF
--- a/crowi/es-statefulset.yaml
+++ b/crowi/es-statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
 
 spec:
   serviceName: es
-  replicas: 1
+  replicas: 0
   podManagementPolicy: Parallel
   revisionHistoryLimit: 0
 

--- a/gitea/act-runner/act-runner.yaml
+++ b/gitea/act-runner/act-runner.yaml
@@ -25,7 +25,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - e505.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
 
       volumes:

--- a/gitea/act-runner/gitea-act-runner.yaml
+++ b/gitea/act-runner/gitea-act-runner.yaml
@@ -95,7 +95,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - e505.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
 
       containers:

--- a/ns-system/components/builder-deployment.yaml
+++ b/ns-system/components/builder-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ns-builder
 
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 0
   selector:
     matchLabels:
@@ -25,7 +25,8 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - e505.tokyotech.org
+                      - c1-203.tokyotech.org
+                      - libra.tokyotech.org
               weight: 1
       topologySpreadConstraints:
         - maxSkew: 1

--- a/traq/es-statefulset.yaml
+++ b/traq/es-statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
 
 spec:
   serviceName: es
-  replicas: 1
+  replicas: 0
   podManagementPolicy: Parallel
   revisionHistoryLimit: 0
 


### PR DESCRIPTION
conoHaのメンテナンスに対応するため
メンテナンスが終わったらRevertする

- ns-build
  - c1-203, libraに移動
- gitea-act-runner
  - c1-203に移動
- elasticsearch
  - 停止