### PR TITLE
staging 用の cluster issuer を分けた

### DIFF
--- a/cert-manager/kustomization.yaml
+++ b/cert-manager/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
   # renovate:github-url
   - https://github.com/cert-manager/cert-manager/releases/download/v1.17.1/cert-manager.yaml
   - cluster-issuer.yaml
+  - staging-cluster-issuer.yaml
 
 generators:
   - ksops.yaml

--- a/cert-manager/staging-cluster-issuer.yaml
+++ b/cert-manager/staging-cluster-issuer.yaml
@@ -1,22 +1,25 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: cluster-issuer
+  name: staging-cluster-issuer
 
 spec:
   acme:
     email: trapsysad@gmail.com
-    server: https://acme-v02.api.letsencrypt.org/directory
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
-      name: cluster-issuer-account-key
+      name: staging-cluster-issuer-account-key
     solvers:
       - http01:
           ingress:
+            ingressClassName: traefik
             serviceType: ClusterIP
             ingressTemplate:
               metadata:
                 annotations:
                   traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+                  acme.cert-manager.io/http01-ingress-class: traefik
+                  acme.cert-manager.io/http01-edit-in-place: 'true'
       - dns01:
           cloudflare:
             apiTokenSecretRef:

--- a/portal-dev/certificate.yaml
+++ b/portal-dev/certificate.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   issuerRef:
     kind: ClusterIssuer
-    name: cluster-issuer
+    name: staging-cluster-issuer
   secretName: portal-dev-tls
   duration: 2160h0m0s # 90d
   renewBefore: 720h0m0s # 30d

--- a/traq-dev/certificate.yaml
+++ b/traq-dev/certificate.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   issuerRef:
     kind: ClusterIssuer
-    name: cluster-issuer
+    name: staging-cluster-issuer
   secretName: traq-dev-tls
   duration: 2160h0m0s # 90d
   renewBefore: 720h0m0s # 30d


### PR DESCRIPTION
traq-dev と portal-dev はとりあえす staging-cluster-issuer を使う用にした