### PR TITLE
traQ-dev に含まれるリソース名をtraQ-server で使われているものに揃える

### DIFF
--- a/traq-dev/backend/config/traq-dev.yaml
+++ b/traq-dev/backend/config/traq-dev.yaml
@@ -4,15 +4,6 @@ pprof: true
 
 allowSignUp: true
 
-mariadb:
-  host: private.kmbk.tokyotech.org
-  port: 33060
-  username: service_traq_r_dev
-  # password: <env secret>
-  database: service_traq_r_dev
-  connection:
-  maxOpen: 10
-
 firebase:
   serviceAccount:
     file: /keys/service-account.json
@@ -27,6 +18,15 @@ gcp:
   stackdriver:
     profiler:
       enabled: true
+
+mariadb:
+  host: private.kmbk.tokyotech.org
+  port: 33060
+  username: service_traq_r_dev
+  # password: <env secret>
+  database: service_traq_r_dev
+  connection:
+  maxOpen: 10
 
 storage:
   type: s3

--- a/traq-dev/backend/deployment.yaml
+++ b/traq-dev/backend/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: traq-dev-backend
-  name: traq-dev
+  name: traq-dev-backend
 spec:
   replicas: 1
   selector:
@@ -22,7 +22,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: traq-dev-backend-config
+            name: traq-dev-config
         - name: keys
           secret:
             secretName: traq-dev-backend-secrets
@@ -41,47 +41,47 @@ spec:
             - mountPath: /app/config.yml
               name: config
               readOnly: true
-              subPath: traq-dev-backend.yaml
+              subPath: traq-dev.yaml
           env:
             - name: TRAQ_MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: mariadb_password
             - name: TRAQ_STORAGE_S3_ACCESSKEY
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: storage_s3_accessKey
             - name: TRAQ_STORAGE_S3_SECRETKEY
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: storage_s3_secretKey
             - name: TRAQ_SKYWAY_SECRETKEY
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: skyway_secretKey
             - name: TRAQ_LIVEKIT_APIKEY
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: livekit_apiKey
             - name: TRAQ_LIVEKIT_APISECRET
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: livekit_apiSecret
             - name: TRAQ_EXTERNALAUTH_TRAQ_CLIENTID
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: externalAuth_traQ_clientId
             - name: TRAQ_EXTERNALAUTH_TRAQ_CLIENTSECRET
               valueFrom:
                 secretKeyRef:
-                  name: traq-dev-backend-config-secrets
+                  name: traq-dev-config-secrets
                   key: externalAuth_traQ_clientSecret
 
       restartPolicy: Always

--- a/traq-dev/backend/kustomization.yaml
+++ b/traq-dev/backend/kustomization.yaml
@@ -4,9 +4,9 @@ resources:
   - ./ingress-route.yaml
 
 configMapGenerator:
-  - name: traq-dev-backend-config
+  - name: traq-dev-config
     files:
-      - config/traq-dev-backend.yaml
+      - config/traq-dev.yaml
 
 generators:
   - ksops.yaml

--- a/traq-dev/backend/secrets/config-secrets.yaml
+++ b/traq-dev/backend/secrets/config-secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: traq-dev-backend-config-secrets
+    name: traq-dev-config-secrets
     annotations:
         kustomize.config.k8s.io/needs-hash: "true"
 stringData:

--- a/traq-dev/backend/secrets/config-secrets.yaml
+++ b/traq-dev/backend/secrets/config-secrets.yaml
@@ -28,8 +28,8 @@ sops:
             VWNTZ3Q1cmNUcXFsY1VVY05DeVJlWVUKkg5c5C63uF9yvDef0jyrvP9g2Aaexl0J
             HEuPEhnqywZsEJpcoM2EWP0FvlKqtLCNRUQ7i8O1KIMIcX0WAoSVmQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-04-30T08:00:24Z"
-    mac: ENC[AES256_GCM,data:LqjwZem3OAyPASxW4tZA6m9XWn4b9yvnZhIXWfedmN+oEdY49RYWHY2N4RYSr/eLv2wG2JovVxYtdeKW8K9LqOUgw32RFk4HK+LSB6fN54n4ad5GCerMdTfDEctDZqAqjjzrBkm4F/58f/vR5b2i+CLv1vD2x+sVhG+Tv9aRTOs=,iv:mz+mV3vBMw+O1SDchQfe+k4XZ5CmfivDEYDySOt4yuk=,tag:i8dczAadSBkfLFzF8Q29Wg==,type:str]
+    lastmodified: "2025-05-05T02:08:13Z"
+    mac: ENC[AES256_GCM,data:LevudezlPaOU0xB8UkF0nJ98VFSE5RViY6QV00lXXZUzQCBH0cwfho2gg4eYOU7hVc/kVhMvbhA6pfWkJcNgI1PHEMkkR95xYbRGot3c65yIcJs+7lfVjsW2MeeiQmhKfjkDndV4I3mof5h9fnz8rGs6oX8gikPM9wbZ8+Qo7MY=,iv:wCrhY8sLxEw7zGhMD2hOgekxWLBCYuEMPdVAejFu16c=,tag:gNBCGM1UyZ3iqT4NiAnvrA==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.1


### PR DESCRIPTION
開発環境と本番環境で記述を統一し、名前の不一致による設定ミスを防ぐため、リソース名を変更しました

`traq-dev/backend/secrets/secrets.yaml`の`metadata-name`を`traq-dev-backend-config-secrets` から`traq-dev-config-secrets`に変更する前提で`traq-dev/backend/deployment.yaml`の`secretKeyRef `を`traq-dev-config-secrets`に変更しています