### PR TITLE
loki compactorの削除対象をs3に変更

### DIFF
--- a/monitor/loki/config/config.yaml
+++ b/monitor/loki/config/config.yaml
@@ -1,7 +1,7 @@
 auth_enabled: false
 
 common:
-  compactor_address: 'loki'
+  compactor_address: "loki"
   path_prefix: /var/loki
   replication_factor: 1
   storage:
@@ -76,8 +76,7 @@ server:
 
 compactor:
   retention_enabled: true
-  delete_request_store: filesystem
-
+  delete_request_store: s3
 #table_manager:
 #  retention_deletes_enabled: true
 #  # 7 days


### PR DESCRIPTION
90日経って、filesystemのログは完全に消えたと思われるため