### PR TITLE
harbor components のメモリ上限を引き上げ

### DIFF
--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -155,7 +155,7 @@ redis:
         memory: "100Mi"
       limits:
         cpu: "100m"
-        memory: "%00Mi"
+        memory: "500Mi"
 
 exporter:
   revisionHistoryLimit: 0

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -155,7 +155,7 @@ redis:
         memory: "100Mi"
       limits:
         cpu: "100m"
-        memory: "200Mi"
+        memory: "%00Mi"
 
 exporter:
   revisionHistoryLimit: 0

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -70,7 +70,7 @@ core:
       memory: "30Mi"
     limits:
       cpu: "300m"
-      memory: "200Mi"
+      memory: "500Mi"
 
 jobservice:
   maxJobWorkers: 1


### PR DESCRIPTION
毎日 OOM Killed されて死んでいるので