### PR TITLE
Renovateオートマージ設定を簡略化、コメント追加

### DIFF
--- a/.github/renovate/auto-merge.json5
+++ b/.github/renovate/auto-merge.json5
@@ -1,13 +1,58 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
+    //// デフォルト動作
+    // patchバージョン、digest、pinDigestは自動マージ
     {
-      "description": "Auto merge GitHub Actions",
-      "matchManagers": ["github-actions"],
-      "matchDatasources": ["github-tags"],
+      "description": "Auto merge up to patch",
       "automerge": true,
-      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"]
+      "matchUpdateTypes": ["patch", "digest", "pinDigest"]
     },
+
+    // 他のルールは必ずこの下に書く
+    // ref: https://docs.renovatebot.com/configuration-options/#packagerules
+    // Order your packageRules so the least important rules are at the top, and the most important rules at the bottom. This way important rules override settings from earlier rules if needed.
+
+    //// traptitechのイメージのデフォルト設定
+    // バージョニングされた全てのアップデートで自動マージしない
+    // digestは開発環境が多いため自動マージ（デフォルト動作）
+    {
+      "description": "Disable auto merge for major, minor, patch for all ghcr.io/traptitech images",
+      "automerge": false,
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchDatasources": ["docker"],
+      "matchDepPatterns": [
+        "/^ghcr\\.io\/traptitech\/.+$/"
+      ]
+    },
+
+    //// 特殊なバージョニングの内製アプリ用設定
+    // portal
+    // 本番環境がlatest、開発環境がstaging
+    // letestは自動マージ無効化
+    {
+      "description": "Disable auto merge for portal production environment",
+      "automerge": false,
+      "matchDatasources": ["docker"],
+      "matchDepPatterns": [
+        "ghcr.io/traptitech/portal"
+      ],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "matchCurrentValue": "/^latest$/"
+    },
+    // portal-pipeline
+    // latestしかないため、全てのアップデートで自動マージを無効化
+    {
+      "description": "Disable auto merge for portal-pipeline production environment",
+      "automerge": false,
+      "matchDatasources": ["docker"],
+      "matchDepPatterns": [
+        "ghcr.io/traptitech/pipeline"
+      ]
+    },
+
+    //// 外部アプリの設定
+    // 一部アプリはminorバージョンまで自動マージ
     {
       "description": "Auto merge up to minor for some images",
       "automerge": true,
@@ -19,11 +64,15 @@
         "paketobuildpacks/builder-jammy-full"
       ]
     },
+    // GitHub Actionsはminorバージョンまで自動マージ
     {
-      "description": "Auto merge up to patch",
+      "description": "Auto merge GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-tags"],
       "automerge": true,
-      "matchUpdateTypes": ["patch", "digest", "pinDigest"]
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"]
     },
+    // アップデートしたら壊れるパッケージの自動マージを無効化
     {
       "description": "Disable auto merge for broken packages",
       "automerge": false,
@@ -31,44 +80,6 @@
       "matchDepPatterns": [
         "mongo"
       ]
-    },
-    {
-      "description": "Disable auto merge for portal production environment",
-      "automerge": false,
-      "matchDatasources": ["docker"],
-      "matchDepPatterns": [
-        "ghcr.io/traptitech/portal"
-      ],
-      "matchUpdateTypes": ["digest", "pinDigest"],
-      "matchCurrentValue": "/^latest$/"
-    },
-    {
-      "description": "Disable auto merge for portal-ui production environment",
-      "automerge": false,
-      "matchDatasources": ["docker"],
-      "matchDepPatterns": [
-        "ghcr.io/traptitech/portal-ui"
-      ],
-      "matchUpdateTypes": ["major", "minor", "patch"]
-    },
-    {
-      "description": "Disable auto merge for portal-pipeline production environment",
-      "automerge": false,
-      "matchDatasources": ["docker"],
-      "matchDepPatterns": [
-        "ghcr.io/traptitech/pipeline"
-      ]
-    },
-    {
-      "description": "Disable auto merge for traQ production environment",
-      "automerge": false,
-      "matchDatasources": ["docker"],
-      "matchDepPatterns": [
-        "ghcr.io/traptitech/traq",
-        "ghcr.io/traptitech/traq-ui",
-        "ghcr.io/traptitech/traq-widget"
-      ],
-      "matchUpdateTypes": ["major", "minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
- auto-merge.json5にコメントを追加
- traP内製アプリの自動マージ停止をOrg単位で行うように