### PR TITLE
使う action の修正 & cache が見つからなくても fail にしないように

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -80,12 +80,13 @@ jobs:
           echo "RENOVATE_DRY_RUN=${{ github.event.inputs.dryRun || env.RENOVATE_DRY_RUN }}" >> "${GITHUB_ENV}"
           echo "LOG_LEVEL=${{ github.event.inputs.logLevel || env.LOG_LEVEL }}" >> "${GITHUB_ENV}"
 
-      - uses: actions/download-artifact@v4
+      - uses: dawidd6/action-download-artifact@v11
         if: github.event.inputs.repoCache != 'disabled'
         continue-on-error: true
         with:
           name: ${{ env.cache_key }}
           path: cache-download
+          if_no_artifact_found: "warn"
 
       - name: Extract renovate cache
         run: |


### PR DESCRIPTION
fix #1083
先の PR では artifact の upload と download で異なる action を使っていたのを修正してもらったが、 download のほうが異なるワークフロー間でも artifact のやり取りを可能にするものだったので、それを復元した

追加で、バージョンを最新のものにしたり、オプションの追加を行った