### PR TITLE
GPT4.1miniの設定を追加

### DIFF
--- a/litellm/config/config.yaml
+++ b/litellm/config/config.yaml
@@ -8,6 +8,10 @@ model_list:
     litellm_params:
       model: openai/gpt-4.1
       api_key: os.environ/OPENAI_API_KEY
+  - model_name: gpt-4.1-mini
+    litellm_params:
+      model: openai/gpt-4.1-mini
+      api_key: os.environ/OPENAI_API_KEY
   - model_name: gpt-4.1-nano
     litellm_params:
       model: openai/gpt-4.1-nano


### PR DESCRIPTION
traPtitech/BOT_GPT#43 におけるコンフリクトに対応するためGPT4.1miniの設定を追加