### PR TITLE
mongoのメモリを増やす

### DIFF
--- a/ns-system/db/mongo-stateful-set.yaml
+++ b/ns-system/db/mongo-stateful-set.yaml
@@ -50,7 +50,7 @@ spec:
           resources:
             requests:
               cpu: "10m"
-              memory: "80Mi"
+              memory: "160Mi"
             limits:
               cpu: "1"
-              memory: "150Mi"
+              memory: "300Mi"


### PR DESCRIPTION
コンテナがOOMするため