### PR TITLE
feat: add github-webhook-secret for argocd

### DIFF
--- a/argocd/ksops.yaml
+++ b/argocd/ksops.yaml
@@ -10,3 +10,4 @@ metadata:
 files:
   - ./secrets/notifications.yaml
   - ./secrets/preview-pr-generator.yaml
+  - ./secrets/github-webhook-secret.yaml

--- a/argocd/patches/argocd-cm.yaml
+++ b/argocd/patches/argocd-cm.yaml
@@ -16,3 +16,5 @@ data:
     |
     jsonPointers:
     - "/spec/preserveUnknownFields"
+
+  webhook.github.secret: $github-webhook-secret:secret

--- a/argocd/secrets/github-webhook-secret.yaml
+++ b/argocd/secrets/github-webhook-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-webhook-secret
+    annotations:
+        kustomize.config.k8s.io/needs-hash: "true"
+    labels:
+        app.kubernetes.io/part-of: argocd
+type: Opaque
+stringData:
+    secret: ENC[AES256_GCM,data:5jw+3wF3/9wXn4F7FhbAWm93gV9SJNHV5vLHHj15Nos=,iv:ieGvqSmCgz+j3DJsAK9NWzO7f4JTIbqvmYPAyliXdnQ=,tag:fCHlCcZXTvh+rChnXoF8qA==,type:str]
+sops:
+    age:
+        - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwYUx5M0ZUdDlFY1JDcnNX
+            NnRZY3NMUjVJaUhKTHgrbGUxbUdzMkt5YkNZClUxYmdMdG5RRnpPb2wzY01GbGQ1
+            SVBuSnVJQkJZREJWeUNNeDJlOXFqUDAKLS0tIHZBbG1DYUZUUFJ5Y21Iek9VUS8r
+            WlV2cmN2YUc0SEV6OFpzZm9vTGNXejgK8wt9gvatSRIhOhFZOKN5DlAKjqFuDDMz
+            7gCFS4QX7QzvzWLAWR5xxnzWI5Jubu2oAT/XE/EM3ZN44OJXk60CHQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-16T08:45:17Z"
+    mac: ENC[AES256_GCM,data:s8/pv/9HwgOz1UItSrUKrL0H8ggqrATw9LTBJtAgQ+kdSe9E14Vz1BgJJQVIL+2IL1hqO6hciFdUyKT8YReLaFvyKPkMCxDRSJ/n43QudB7U3FyQk7TzYiFGCB1BvH7RDVaRorgkN6gaAtmJtkaa1hheWm/msOJHHeXUuuuyhtA=,iv:eq/2g3ZN8Y9k9nZT1ba0iyyTm12ewXabqe6qWevWKt4=,tag:Nc9psK4NzJD0n7IUuUjqDA==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.10.2


### PR DESCRIPTION
close: #1162
## やったこと
- argocd/ 以下の `patches/argocd-cm.yaml` に webhook URL を追加
- 新しく github-webhook-secret.yaml を追加

## 質問
- sakura-argocd/ 以下に patches/argocd-cm.yaml や secrets/ ディレクトリが存在しないのですが、同様に追加する方針でよいですか？
- Secret の平文はあとでAdminにDMなどで伝えればよいですか？

## 備考
- まだsakura-argocdの方ができていないのでDraft PRにしています。