### PR TITLE
feat(dev-ops-bot): Jomonのdeployコマンドで引数を受け取れるように変更

### DIFF
--- a/dev-ops-bot/config/config.yaml
+++ b/dev-ops-bot/config/config.yaml
@@ -330,6 +330,7 @@ commands:
           - s323.tokyotech.org
           - /srv/jomon/deploy.sh
         allowArgs: true
+        argsSyntax: "[<image_tag>] (default: latest)"
         operators:
           - hijiki51
           - Takeno_hito


### PR DESCRIPTION
`allowArgs: true` を設定し、デプロイ時にイメージタグを引数に渡せるようにしました。