### PR TITLE
イメージアップデート用正規表現を修正

### DIFF
--- a/.github/renovate/regex-manager.json5
+++ b/.github/renovate/regex-manager.json5
@@ -25,7 +25,7 @@
       description: "OCI image dependencies (full)",
       managerFilePatterns: ["/.+/"],
       matchStrings: [
-        '# renovate:image-full\n.*?"(?<registryUrl>[^\\s/]+)/(?<depName>[^\\s:]+):(?<currentValue>.+)"\n',
+        '# renovate:image-full\n.*?"(?<registryUrl>[^\\s/]+)/(?<depName>[^\\s:]+):(?<currentValue>[^"@]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?"\n',
       ],
       datasourceTemplate: "docker",
       registryUrlTemplate: "https://{{{registryUrl}}}",


### PR DESCRIPTION
```
ghcr.io/traptitech/traq-ui:master@sha256:17acccd9bbabdea9c5d763a6da6c26d678386e4df8a785fee5fdcc2b21b2bf7a
```

とあったときに、

- `currentValue`: `master`
- `currentDigest`: `sha256:17acccd9bbabdea9c5d763a6da6c26d678386e4df8a785fee5fdcc2b21b2bf7a`

となるべきところが

- `currentValue`: `master@sha256:17acccd9bbabdea9c5d763a6da6c26d678386e4df8a785fee5fdcc2b21b2bf7a`
- `currentDigest`: なし

となっていた問題を修正