### PR TITLE
hotfix: エンコードされた`#`(`%23`)を含むリクエストに対応。

### DIFF
--- a/traefik/config/traefik.yaml
+++ b/traefik/config/traefik.yaml
@@ -33,6 +33,8 @@ entryPoints:
       middlewares:
         - compress@file
         - errors-5xx@file
+      encodedCharacters:
+        allowEncodedHash: true
     # NOTE: Setting HTTP request body read timeout from default of 60s to 300s,
     # since our bandwidth on ConoHa is slow (100Mbps).
     # This could affect long-lasting uploads like docker registry uploads.
@@ -47,6 +49,8 @@ entryPoints:
       middlewares:
         - compress@file
         - errors-5xx@file
+      encodedCharacters:
+        allowEncodedHash: true
     http3: {}
     # NOTE: Setting HTTP request body read timeout from default of 60s to 300s,
     # since our bandwidth on ConoHa is slow (100Mbps).


### PR DESCRIPTION
https://github.com/traPtitech/manifest/pull/1241 で懸念点として挙げられていて実際に問題が発生したため対応。
具体的にはpublic API `/public/icon/{username}` でアクセスされるicon画像の中でWebhookのアイコンが取得できなかった。
Webhookのidは`Webhook#...`といった命名規則であり、必ず`#`を含むためである。