### PR TITLE
configure pyroscope resources

### DIFF
--- a/monitor/pyroscope/values.yaml
+++ b/monitor/pyroscope/values.yaml
@@ -13,7 +13,16 @@ pyroscope:
         secretKeyRef:
           name: s3-credentials
           key: s3-secret-key
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
   config: |
+    pyroscopedb:
+      max-block-duration: 1h
     storage:
       backend: s3
       s3:


### PR DESCRIPTION
`pyroscopedb.max-block-duration`を短めに設定するとメモリ消費を抑えられるみたいなのでついでに設定してみました
https://github.com/grafana/pyroscope/blob/next/operations/pyroscope/helm/pyroscope/values.yaml#L74