### PR TITLE
fix: Jomon deployment

### DIFF
--- a/jomon-dev/deployment-patch.yaml
+++ b/jomon-dev/deployment-patch.yaml
@@ -16,7 +16,10 @@ spec:
             - name: UPLOAD_DIR
               value: "./uploads"
             - name: SESSION_KEY
-              value: "session"
+              valueFrom:
+                secretKeyRef:
+                  name: jomon-secret
+                  key: SESSION_KEY
             - name: TRAQ_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -48,11 +51,9 @@ spec:
                   name: jomon-secret
                   key: MARIADB_PASSWORD
             - name: MARIADB_HOSTNAME
-              value: "tailscale.kmbk.tokyotech.org"
+              value: "tailscale.kmbk.tokyotech.org:33060"
             - name: MARIADB_DATABASE
               value: "service_jomon_dev"
-            - name: MARIADB_PORT
-              value: "33060"
             - name: OS_CONTAINER
               value: "jomon-dev"
             - name: OS_USERNAME

--- a/jomon-dev/secrets/secrets.enc.yaml
+++ b/jomon-dev/secrets/secrets.enc.yaml
@@ -9,7 +9,7 @@ stringData:
     PORT: ENC[AES256_GCM,data:hOya8g==,iv:B2kRs179l24glWGi5VidqGrHn29z5spukFqLWJWAypo=,tag:uyyIO6bBFktxAVuIssnl+Q==,type:str]
     HOST: ENC[AES256_GCM,data:k/2R/5TmCjAtXawScbZp1Ck=,iv:baNNl/DVjrdg4JYrU8l1sNlLkmque59LIxE4vW+0ayc=,tag:XFmFJMZTEwF7P682C6qVoQ==,type:str]
     UPLOAD_DIR: ENC[AES256_GCM,data:uWe1FT0R1q1G,iv:DotymMXa/r+Zj1AQGHNY5FSC5mI6lPOfrKLSiSdyK44=,tag:BK268PCxv5Z6XCuKxLc3sw==,type:str]
-    SESSION_KEY: ENC[AES256_GCM,data:/ccekA74EQ==,iv:A+3Q+InGPSBK2zb/8YNTdml5CvOVvEXFGhzqiytA688=,tag:h1Cyq0Urep0yNBhUsdZBzQ==,type:str]
+    SESSION_KEY: ENC[AES256_GCM,data:quslqbLMAgXYjXOkUPk65l6MZp/nPsVWDda8PFsYJ90=,iv:fbeso9+suedZRc5R+pYEtzGlbUss+3bc9EosTpeFH1U=,tag:2VQDcP22CfnKcfDgo2r6EA==,type:str]
     TRAQ_CLIENT_ID: ENC[AES256_GCM,data:nNY1nC5toTSWleCit4qD7mej/kZAlRVL0x3E94RkqAgdHVqr,iv:nOl2wNES/ABl79AIHBJIjHykENhUw4RYxrax1WvpBwQ=,tag:nVRzhfaMy62dro3GweWlvw==,type:str]
     WEBHOOK_SECRET: ENC[AES256_GCM,data:YZNWp/zULmkQBCduYG3t3/oQsOo=,iv:3+OdxC3xyHdeuGm+G4DHz3v8E+wD2zqNPKXld8eDv9Y=,tag:x0LpeUt7PsdgJK4y88hf8A==,type:str]
     WEBHOOK_CHANNEL_ID: ENC[AES256_GCM,data:qD7c2rJyX5qieEbfgyhONX4esipHcDK2OGkev2v+wyVLSyTF,iv:bRyf6zGQxXUScyzwDfzQ7HG7qjtPE0NesfUYa7Xkiz0=,tag:/jN6F3cslIJyUXnyhJf03A==,type:str]
@@ -18,7 +18,6 @@ stringData:
     MARIADB_PASSWORD: ENC[AES256_GCM,data:0kL9ccrybE4GUuUVuGmrJIxZIQfie71kazz6dqy2I1g=,iv:QMJiWoWETzfGHwv9FUex91HzRkulPnnoigWVdVwRhZY=,tag:TaNAq1PrPFN+gPx2WJkq5g==,type:str]
     MARIADB_HOSTNAME: ENC[AES256_GCM,data:4MjGUss/0gMhNOEqKLR7xTcxlE0vRQTz1RFdAQ==,iv:q2MtA2IxpiRKUnp3FSOHbHeoSHantdhULJAPPrmDiqk=,tag:CtiEYwANtgkB04ZKZxuUDw==,type:str]
     MARIADB_DATABASE: ENC[AES256_GCM,data:n/A+aVPPMbaU7lOnpQlP+RQ=,iv:qKlXQX+IvS2aonZRRtPt0h8k1quJTIc0XBmgScJ5Zgw=,tag:LMxuSwJ4My/mLVkMOycdCg==,type:str]
-    MARIADB_PORT: ENC[AES256_GCM,data:qUfKOEU=,iv:9FMI5NP+YyttgdV3avoaR6lke0FYoQFhJVTlIvuaw9A=,tag:bpcYrfvbWsHHE9uy2DQ+rQ==,type:str]
     OS_CONTAINER: ENC[AES256_GCM,data:ffl8I2As2P82,iv:7wbHuc8yxQXogAwCHfvbWF9phtODBbyvDTbRcZeG/fI=,tag:O2Q5A9OSpPYMRxkn1MsSug==,type:str]
     OS_USERNAME: ENC[AES256_GCM,data:+XdQ959jermCEAxt,iv:C+9eXRQH2npVKdGWSRFqT5nNfOAQWPWlroqvFTG033Y=,tag:vuNjJQzliKQmmgk5hhl+9Q==,type:str]
     OS_PASSWORD: ENC[AES256_GCM,data:ZQDPkDSxQgo3xWlZ,iv:sNQZnu9SX0RQHk/Skw732ofqFtEKB0/HgBMa4fINMRQ=,tag:gr2mPwoKaSFyOgVHxTCNBg==,type:str]
@@ -40,8 +39,8 @@ sops:
             dWRod0NoSDNOUkt2YkR5Uno4Uk5zZU0K+xp0MZrzMsJ8FI2xaZtB1dR/8Uz4Fp+t
             Mjpb3ZtLKSdwnvB5HgSL5/HbJ3WvjkE6eYNhOazx4tdEYW1av6dy/Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-15T07:07:18Z"
-    mac: ENC[AES256_GCM,data:rWGlBOOa4kaTXU58Z2HP9xpq47dD6d/H/BkUt+XtACo+E5g77+uYM9V+QYgFDBVSiogEYo3t9j95dkSI+g8Kltrr94I7e6pHrDUKk0w/5heqdqxDCQdgaduXj+w7Ukz+shh8u+EjIAlvcFBxAfSE7BbLX+bwfTI/j90mf/DxTFI=,iv:dKgr9M75EXtQFVD57nJQanQwj/SOHzwRjOJA9l0BM28=,tag:EKYAXZdJzA4gNIAQnG4orA==,type:str]
+    lastmodified: "2026-01-18T05:51:45Z"
+    mac: ENC[AES256_GCM,data:KqP5nFvAcYNItKJkEbP66gn6MNGTLNeOXhGFOTEtwpsomdDfEXmzorAiB6wLAy+k9dAg3vZx7x3BwLPTEuebEVi5LWmySVyI7CD0WBNKEtwl8BVEFdxifTRLTgR6TffQ8PwBomcstdFayg/xKUb2hSWw9raVx2jQpmOo6w9/0fQ=,iv:BAOp5chP2c0ZKrqlHkXLzEjzxSCIvZYhQ9ItIJsvY3s=,tag:GDkdcOkJCvPTvQSpqgCU1A==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.9.1

--- a/jomon/deployment.yaml
+++ b/jomon/deployment.yaml
@@ -36,7 +36,7 @@ spec:
                   name: jomon-secret
                   key: MARIADB_PASSWORD
             - name: MARIADB_HOSTNAME
-              value: "tailscale.kmbk.tokyotech.org"
+              value: "tailscale.kmbk.tokyotech.org:3306"
             - name: MARIADB_DATABASE
               value: "service_jomon"
             - name: OS_CONTAINER


### PR DESCRIPTION
Jomon v1 が `MARIADB_PORT` 環境変数を受け入れていなかったので `MARIADB_HOSTNAME` に含めるようにした

実装の該当箇所: https://github.com/traPtitech/Jomon/blob/master/model/db.go#L23