### PR TITLE
rucQの起動状態を監視するように

### DIFF
--- a/sakura-monitor/victoria-metrics/config/prometheus.yml
+++ b/sakura-monitor/victoria-metrics/config/prometheus.yml
@@ -416,7 +416,7 @@ scrape_configs:
         target_label: node
     metric_relabel_configs:
       - source_labels: [service]
-        regex: 'ns-apps.*'
+        regex: "ns-apps.*"
         action: drop
 
   # TODO: replace with service annotation "prometheus.io/scrape: true" once service is running on the cluster
@@ -561,6 +561,7 @@ scrape_configs:
           - https://portfolio-admin.trap.jp
           - https://llm-proxy.trap.jp
           - https://s3-dev.trap.jp
+          - https://rucq.trap.jp
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -578,16 +579,16 @@ scrape_configs:
         - icmp
     static_configs:
       - targets:
-        - ict201.tokyotech.org
-        - ict202.tokyotech.org
-        - ict203.tokyotech.org
-        - private.csc301.tokyotech.org
-        - private.sce311.tokyotech.org
-        - private.iee221.tokyotech.org
-        - eee101.tokyotech.org
-        - arc321.tokyotech.org
-        - mcs331.tokyotech.org
-        - las211.tokyotech.org
+          - ict201.tokyotech.org
+          - ict202.tokyotech.org
+          - ict203.tokyotech.org
+          - private.csc301.tokyotech.org
+          - private.sce311.tokyotech.org
+          - private.iee221.tokyotech.org
+          - eee101.tokyotech.org
+          - arc321.tokyotech.org
+          - mcs331.tokyotech.org
+          - las211.tokyotech.org
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
blackbox-exporterにrucQ(rucq.trap.jp)を追加