### PR TITLE
argocd-repo-serverがClusterRoleをlistできるように

### DIFF
--- a/argocd/repo-server-cr.yaml
+++ b/argocd/repo-server-cr.yaml
@@ -6,3 +6,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps", "secrets"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
longhornのインストール時のエラーに対応