### PR TITLE
longhorn-managerのnodeSelectorを修正

### DIFF
--- a/longhorn-system/values.yaml
+++ b/longhorn-system/values.yaml
@@ -1,11 +1,15 @@
 global:
-  nodeSelector:
-    kubernetes.io/hostname: csc301.tokyotech.org
   timezone: Asia/Tokyo
 
+# nodeSelector設定
 longhornManager:
+  nodeSelector: {}
+longhornDriver:
   nodeSelector:
-    kubernetes.io/os: linux
+    kubernetes.io/hostname: csc301.tokyotech.org
+longhornUI:
+  nodeSelector:
+    kubernetes.io/hostname: csc301.tokyotech.org
 
 persistence:
   defaultClass: false # 性能をどの程度要求するか不明なため、一旦デフォルトにしない


### PR DESCRIPTION
`{}`にしたら`global`が適用されてしまったため、確実に全Nodeが対象になるラベルにした