### PR TITLE
hotfix: NeoShowcase の Pod Scheduling で一定の skew を許可するように

### DIFF
--- a/ns-system/config/ns.yaml
+++ b/ns-system/config/ns.yaml
@@ -156,7 +156,7 @@ components:
             operator: Exists
             effect: NoSchedule
         spreadConstraints:
-          - maxSkew: 1
+          - maxSkew: 10
             topologyKey: kubernetes.io/hostname
             whenUnsatisfiable: DoNotSchedule
             labelSelector:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * システムスケジューリングポリシーを更新し、ポッド配置の制約を緩和しました。これにより、クラスタ内のリソース分散がより柔軟に最適化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->