### PR TITLE
feat: Sync OptionにServerSideApplyを指定

### DIFF
--- a/applications/application-set.yaml
+++ b/applications/application-set.yaml
@@ -84,7 +84,7 @@ spec:
       syncPolicy:
         syncOptions:
           - CreateNamespace=true
-          -  ServerSideApply=true
+          - ServerSideApply=true
         automated:
           prune: true
           selfHeal: true


### PR DESCRIPTION
annotation sizeが大きすぎて失敗するエラーの対処

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 同期プロセスでサーバーサイド適用が有効になりました。これにより同期時のリソースのマージや更新の振る舞いが変わる可能性があります。既存のネームスペース作成オプションは引き続き適用されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->