### PR TITLE
knoqのauth middlewareを削除

### DIFF
--- a/knoq-dev/ingress-route-patch.yaml
+++ b/knoq-dev/ingress-route-patch.yaml
@@ -13,9 +13,6 @@ spec:
           port: 3000
     - match: Host(`knoq-dev.trapti.tech`)
       kind: Rule
-      middlewares:
-        - name: auth-trapti-tech-hard
-          namespace: auth
       services:
         - name: knoq-frontend
           port: 80

--- a/knoq/ingress-route.yaml
+++ b/knoq/ingress-route.yaml
@@ -8,17 +8,11 @@ spec:
   routes:
     - match: Host(`knoq.trap.jp`) && PathPrefix(`/api`)
       kind: Rule
-      middlewares:
-        - name: auth-trap-jp-hard
-          namespace: auth
       services:
         - name: knoq-backend
           port: 3000
     - match: Host(`knoq.trap.jp`)
       kind: Rule
-      middlewares:
-        - name: auth-trap-jp-hard
-          namespace: auth
       services:
         - name: knoq-frontend
           port: 80


### PR DESCRIPTION
ログインはOAuth方式のため必要ない・認証不要なapiに認証がかかり不具合を起こすため