### PR TITLE
chore(traefik): ログ設定を info / json に

### DIFF
--- a/traefik/config/traefik.yaml
+++ b/traefik/config/traefik.yaml
@@ -63,3 +63,7 @@ entryPoints:
     address: :8080/tcp
   metrics:
     address: :9100/tcp
+
+log:
+  level: INFO
+  format: json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ロギング**
  * グローバルロギング設定が追加されました。ログレベルがINFOに設定され、ログフォーマットはJSON形式に統一されます。これによりランタイムログメッセージの出力形式が一貫性を持つようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->