### PR TITLE
cert-managerをHelmに移行

### DIFF
--- a/cert-manager/kustomization.yaml
+++ b/cert-manager/kustomization.yaml
@@ -10,6 +10,7 @@ helmCharts:
     valuesFile: ./values.yaml
 
 resources:
+  - namespace.yaml
   - cluster-issuer.yaml
   - staging-cluster-issuer.yaml
   - dns-cluster-issuer.yaml

--- a/cert-manager/kustomization.yaml
+++ b/cert-manager/kustomization.yaml
@@ -1,6 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: cert-manager
+    repo: https://charts.jetstack.io
+    releaseName: cert-manager
+    version: v1.20.2
+    namespace: cert-manager
+    valuesFile: ./values.yaml
+
 resources:
-  # renovate:github-url
-  - https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml
   - cluster-issuer.yaml
   - staging-cluster-issuer.yaml
   - dns-cluster-issuer.yaml

--- a/cert-manager/namespace.yaml
+++ b/cert-manager/namespace.yaml
@@ -1,0 +1,6 @@
+# https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml
+# ↑を利用していたとき、Namespaceがmanifestに含まれていていたため、Helm移行時にArgoCDによって削除されないように明示的に作成
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/cert-manager/values.yaml
+++ b/cert-manager/values.yaml
@@ -1,0 +1,2 @@
+crds:
+  enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * cert-manager のインストール方法を Helm チャートベースに変更しました（v1.20.2 にピン留め）。
  * cert-manager による CRD（カスタムリソース定義）の自動管理を有効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->