### PR TITLE
fix: fireworksのパスを少し調整

### DIFF
--- a/litellm/config/config.yaml
+++ b/litellm/config/config.yaml
@@ -66,15 +66,15 @@ model_list:
       api_key: os.environ/OPENAI_API_KEY
   - model_name: kimi-k2p6
     litellm_params:
-      model: fireworks_ai/kimi-k2p6
+      model: fireworks_ai/accounts/fireworks/models/kimi-k2p6
       api_key: os.environ/FIREWORKS_API_KEY
   - model_name: gpt-oss-120b
     litellm_params:
-      model: fireworks_ai/gpt-oss-120b
+      model: fireworks_ai/accounts/fireworks/models/gpt-oss-120b
       api_key: os.environ/FIREWORKS_API_KEY
   - model_name: qwen3p6-plus
     litellm_params:
-      model: fireworks_ai/qwen3p6-plus
+      model: fireworks_ai/accounts/fireworks/models/qwen3p6-plus
       api_key: os.environ/FIREWORKS_API_KEY
 litellm_settings:
   num_retries: 3


### PR DESCRIPTION
価格が自動で読み込まれなかったのは、パスが省略形のためかもしれないので修正してみる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **設定変更**
  * Fireworksバックエンドの3つのモデル（`kimi-k2p6`、`gpt-oss-120b`、`qwen3p6-plus`）のモデルパスを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->