### PR TITLE
add nextcloud-dev

### DIFF
--- a/applications/application-set.yaml
+++ b/applications/application-set.yaml
@@ -75,6 +75,8 @@ spec:
             exclude: true
           - path: "portal-dev"
             exclude: true
+          - path: "nextcloud-dev"
+            exclude: true
   template:
     metadata:
       name: "{{.path.basename}}"

--- a/nextcloud-dev/certificate.yaml
+++ b/nextcloud-dev/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nextcloud-dev-tls
+spec:
+  secretName: nextcloud-dev-tls
+  duration: 2160h0m0s # 90d
+  renewBefore: 720h0m0s # 30d
+  issuerRef:
+    kind: ClusterIssuer
+    name: dns-cluster-issuer
+  dnsNames:
+    - "drive-dev.trapti.tech"

--- a/nextcloud-dev/ingress-route.yaml
+++ b/nextcloud-dev/ingress-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: nextcloud-dev
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`drive-dev.trapti.tech`)
+      services:
+        - name: nextcloud
+          port: 8080
+  tls:
+    secretName: nextcloud-dev-tls

--- a/nextcloud-dev/ksops.yaml
+++ b/nextcloud-dev/ksops.yaml
@@ -1,0 +1,14 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+   name: ksops
+   annotations:
+      config.kubernetes.io/function: |
+         exec:
+           path: ksops
+
+files:
+  - ./secrets/db.enc.yaml
+  - ./secrets/nc_secrets.enc.yaml
+  - ./secrets/redis.enc.yaml
+  - ./secrets/s3.enc.yaml

--- a/nextcloud-dev/kustomization.yaml
+++ b/nextcloud-dev/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - repo: https://nextcloud.github.io/helm/
+    name: nextcloud
+    version: 9.0.5
+    namespace: nextcloud-dev
+    releaseName: nextcloud
+    valuesFile: values.yaml
+
+resources:
+  - certificate.yaml
+  - ingress-route.yaml
+
+generators:
+  - ksops.yaml

--- a/nextcloud-dev/secrets/db.enc.yaml
+++ b/nextcloud-dev/secrets/db.enc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: nextcloud-db
+stringData:
+    username: ENC[AES256_GCM,data:iy6Dn4hnkDSiRdZI+WDGHcM=,iv:Mxdo5kb9oW1UtDN5Yi382ozt48LlpD3wgTgYhoOBaJE=,tag:o654iq4QpyO8qBPHP/bB4A==,type:str]
+    password: ENC[AES256_GCM,data:t0NGV8DlaqEJ25aKdT5PhdO3fk4u9fDhUS7EGeZPuZNJC5GIgW8ledbZ2a3tqghE5Vqh3SXrKFu/PoOi/6USlw==,iv:ggYZnrcqxiL8Ng1Goj1JvVMMSHesUceS967x4AijwEg=,tag:u8b1II29FGLF2yLjx5f4jA==,type:str]
+sops:
+    age:
+        - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJdEphNk9CNE50SGpsMm9L
+            cFZiZmpjL3Naai81cWtiYy9kYkNxYWJTM2dZCktsbndLYkd0eTlCM25NV3NTNUhk
+            K0c2TlpQUmJBQng0YkEvaDFGWFE4WjAKLS0tIEN1ZllTQkRvZ21UN1pQMlR3NHFX
+            ZHZFS2FaRnpRN1QydDdqOEg1S0x0NUkKQhi3qfsnYPJWZhbrYowYhMMBihYvBw0+
+            QUOsrNlW+W4iGx99jCXeL2RtR4s1rKOA92JUL/B2zTF5t0bd0vhDLA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-01T14:01:58Z"
+    mac: ENC[AES256_GCM,data:Q2TNWWpVcZZdN4U1Y6gV1C0uuWUx3hbk2ouOvzUToL2XZ6sJdv//TnayC8a2sEAr8ZPW+mItTzVwXkmzeiqnJCr7fcwFF0h1R5mVwfaa/nyyoRN0ElZbaPPyBY/YfxM9SkKysv7A2L91AepwIEVFHsG6NwYhOxhiTm68VTSI/4s=,iv:6MObVf+7M/j8BqtOUFbe+JHcSvQFcX1wVVfc5eBjfJE=,tag:ROCLpUjCcUJwcsJyR+Sasw==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.12.2

--- a/nextcloud-dev/secrets/nc_secrets.enc.yaml
+++ b/nextcloud-dev/secrets/nc_secrets.enc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: nextcloud-secrets
+stringData:
+    smtp-username: ENC[AES256_GCM,data:6+ueHjXN,iv:SAnLdSdWKLCQvRqsWn6kkCAKi3EPOvS2G5kZZBSJKNg=,tag:LrZHmJ4fDIHM5YX1SoI4YA==,type:str]
+    smtp-password: ENC[AES256_GCM,data:nTIqXXTGkxfXRxVgXp5+O2meXLAdycPkxcciziUO283NEnKTLgRGhT7wrzsEoIsokhucTcSFby/fWStuHTiFcSeuREOx,iv:NVUrd8rBBglsPcLeLejP4NTBbwwF4MRR0eVaRPmrbc4=,tag:WWmcTCWlEpowzB5k0u14Yw==,type:str]
+    smtp-host: ENC[AES256_GCM,data:8WNpCni5OkIauMOL9IrOiqk=,iv:qMskSY4vpPMBEd2HeFZYknP4ItGfILUvoDSN3yCBqBs=,tag:EybMtkgO9sEOQX/KbvRARA==,type:str]
+    nc_secret: ENC[AES256_GCM,data:EklM9fTTELRUoMeWE4VusknyNzy0Qr6AC60uDLhHFB6CReyNQdOsezD76QAZaiFX,iv:irpR5lJInCe5GPaiEGOru21Pdnj5rlAT3TTa3TVSVis=,tag:MOkuTd5CWFIQ8p5w/OxrUw==,type:str]
+    nc_passwordsalt: ENC[AES256_GCM,data:6OPOMZ9tHqaYRcQbIMDVb3HnlhvCuHyNZRnbX079,iv:TDNQsMsJ4UvVjoqC0/9oTENF6BY348vTWiWyzJR4qI4=,tag:z9Fuz7OdhPhQ3jrP4weIDw==,type:str]
+    nc_instanceid: ENC[AES256_GCM,data:x6pJt5Ur1yeJZuCN,iv:NsyAKfEwipoV3ksSqhSVQar65VuhseRuYhizZER5onU=,tag:WPqSFTgnX6+ipO81a9aHSA==,type:str]
+sops:
+    age:
+        - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsb1ZQd203SmZ6TWhFR2d0
+            ZVhYZUZIWkc4VEZzTXZXU0Frd083MmJic2tzCk5DK2cwRjBxTjdEVkswMmJLUUg5
+            L2E3RXVIalVtRnZJM0w4d0swMitWbEEKLS0tIDZLM2FiM2xHbTNSdWtUck5jL3Fl
+            Um52OHViRkkrRFNZTGFNQkJnNUhNZG8KBBsPpDe8pwAm32dhSMB0GhJRzkMb42gz
+            htcty2JDLYcKkkuZJBKA+xwnAyYVtxXrszROjVZT6GWPjKy2EarDwA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-02T01:57:42Z"
+    mac: ENC[AES256_GCM,data:HTYi2lnpjLq9i/f05QsrabQwfeO/krfDNsCZ249vdxTx+8R90Q/5ZhltDAJK8whkYfIMnY8ZP6ZmPecpI5JUHav5VpBdQXlRUkCFikjjg/tn9N59sbcW0sQSLZ+wHuYXoka0aRidn77PY67KtEPbzUImk/XZ/tJmldOyA+/I1Gg=,iv:vKekKeotjwTVtQT9r8g3yVsyjh9pTZWYeVSR9p/uJcI=,tag:FzY5tmLWqUjs2wLvIYKDjg==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.12.2

--- a/nextcloud-dev/secrets/redis.enc.yaml
+++ b/nextcloud-dev/secrets/redis.enc.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: nextcloud-redis
+stringData:
+    password: ENC[AES256_GCM,data:T0GPBfsBCjjY0lIW74XTdew0EkAvq/9D,iv:40wjJm1msMLIQD9nJ+uFn0JPSexdt+W9QrvqvDTQrRc=,tag:UnRF7HPQMjw9np65JoXb7w==,type:str]
+sops:
+    age:
+        - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXbGxaalNUeGVISnBUNTlj
+            MXBxYjJHS1p4OWZjNjMyMzlDbTlTMmgraVRvCnVsY2V2QlNsMlI3TXg1UjA4OG1R
+            NVhXd3MrT213NmZ3ejIvdHhkQWVnYWcKLS0tIGtsUDRPZU44dCs3N3pXbnBqL0FU
+            UGszNGR3MGUyQjRYc0tnTFpLdFRoRlEK0KWNUKNeTTqBmwV+HqY5LB0kotAc2MO8
+            XN6RDaW3MkQZJAZjpNo3dLxUVk9tqHSmfc8hT+Bql+tqsIIuSZTLog==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-01T14:06:51Z"
+    mac: ENC[AES256_GCM,data:3hUFvvR72HTxPEPPb+uF2AU3bzmJ/U7Aj9CxhHQ+rgTPM7VUfXPcU2VhYNrzdCf80G79btjjwwBxviqDgaoJySUD7lr/SBPxI3SVZbYbmiJZR/IK3UQBGqVzLQUFxP4IkNzWknZ7+2BOzAZ6q0ufNA5NAtyAv5T2Z+7WnsnF3ag=,iv:VT6B7mWjCAvv/9eJDOHax6YnR4rhvuq2XPq7tA1Bb/c=,tag:g8da6QiG/zf92CewOMqphQ==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.12.2

--- a/nextcloud-dev/secrets/s3.enc.yaml
+++ b/nextcloud-dev/secrets/s3.enc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: nextcloud-s3
+stringData:
+    host: ENC[AES256_GCM,data:uK7NKXSa+69rU4B0lNHzg/wCAeBV1EcpYVnjdfhCZQ==,iv:onKTc4gCSj7XL9QNGagi1plI/9ZFL/S/m5/QBqI0Nzo=,tag:+RkIgiVZggz6BpfIO3eR0Q==,type:str]
+    accessKey: ENC[AES256_GCM,data:Aa+znGxHS/FDBST96nZAHrFNGnc=,iv:NtcmNvpmwOpdzS4UFt2vCRcj4TdrpLTFVfew/Ri8C8o=,tag:Jw7QZjIj6BZvBa1nExIqCw==,type:str]
+    secretKey: ENC[AES256_GCM,data:uSUGl5YqTkK7ppn9YtfGixR5rvNkwe5VYAZXOfOZk8F3kzUzIN72QA==,iv:GaSVyjz6CZxbALyI35+vpfwcsvcG2kp5K9u72UAD6JI=,tag:k00oW0k6SLRblym9PPW2Zw==,type:str]
+    bucket: ENC[AES256_GCM,data:4GjTmPnD33KRh7T46fvjULku,iv:8j2fnvUdX1Kf4mQh9qJRiTJNLkieNKnVtafNEhFkpkA=,tag:K7GOFwgE1jRpQEczBHL6vg==,type:str]
+sops:
+    age:
+        - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEbEMvTzZRNzBPcG1ZWFVR
+            K0Zpajh0TGNNS0dsSjgvdlQ1bGxiYUdXR0hZCkRwT0w5cHFaUUp5Zk8yMUxhSjlj
+            UDJ1MjY3M1d1MzEreENsTUpiSzErSlkKLS0tICtETVRpdWptcTVsMklrQ1lYTHBI
+            K0ZVOEFOOEtWYjhlYWZFdzZwTVRnZVUK8KOg9TVzfnyYZvwQ0VUttBA++4QUznzu
+            bvc0I7RvChRqVRfDgvjkQAQug3EEikLl+IWQKXqxGcRzk9dHIvRCxA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-02T06:08:40Z"
+    mac: ENC[AES256_GCM,data:UJvLLVeHBx6XDBA/FlJ8pyVIw/aDqhq5VGCX1GGYbM9KeluWTywp+dczMau04U6UndpkSVvgOLeNrAurrvVAZkVi+6yWvy194fGqVuXNFqd8nhuReqLpkWtDdoY63weMkFpr3LcvjOw/JFXeB1CWgmgfuZZQX/CIzXVmN2f7duM=,iv:Axh24jdzzwkcanLbF6VcM984+XP9g2MmSjLLf5OLMco=,tag:ASB8N2pnxnzyvSx2b+OXGQ==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.12.2

--- a/nextcloud-dev/secrets/s3.enc.yaml
+++ b/nextcloud-dev/secrets/s3.enc.yaml
@@ -3,22 +3,20 @@ kind: Secret
 metadata:
     name: nextcloud-s3
 stringData:
-    host: ENC[AES256_GCM,data:uK7NKXSa+69rU4B0lNHzg/wCAeBV1EcpYVnjdfhCZQ==,iv:onKTc4gCSj7XL9QNGagi1plI/9ZFL/S/m5/QBqI0Nzo=,tag:+RkIgiVZggz6BpfIO3eR0Q==,type:str]
-    accessKey: ENC[AES256_GCM,data:Aa+znGxHS/FDBST96nZAHrFNGnc=,iv:NtcmNvpmwOpdzS4UFt2vCRcj4TdrpLTFVfew/Ri8C8o=,tag:Jw7QZjIj6BZvBa1nExIqCw==,type:str]
-    secretKey: ENC[AES256_GCM,data:uSUGl5YqTkK7ppn9YtfGixR5rvNkwe5VYAZXOfOZk8F3kzUzIN72QA==,iv:GaSVyjz6CZxbALyI35+vpfwcsvcG2kp5K9u72UAD6JI=,tag:k00oW0k6SLRblym9PPW2Zw==,type:str]
-    bucket: ENC[AES256_GCM,data:4GjTmPnD33KRh7T46fvjULku,iv:8j2fnvUdX1Kf4mQh9qJRiTJNLkieNKnVtafNEhFkpkA=,tag:K7GOFwgE1jRpQEczBHL6vg==,type:str]
+    accessKey: ENC[AES256_GCM,data:1+6suP8aYFe5KTqM9ASJBxul8dY=,iv:yj18MO8kPWyUqBG4uls+xVlkyRb/JT3gxbGFGiYS/v0=,tag:eGbfIcwxUNr+zNM8CK3shg==,type:str]
+    secretKey: ENC[AES256_GCM,data:Z5nhKnTG2WDrL43DxsRWHIlX5BLfrJwP3aeDCkmziFZN2i0M30osUw==,iv:xDt262o9ZVlZF3d3/AUCKzm/5yG4XBXSeKdtEuMt1J8=,tag:gyXpzLv3oFcs/nvGc1PXCg==,type:str]
 sops:
     age:
         - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEbEMvTzZRNzBPcG1ZWFVR
-            K0Zpajh0TGNNS0dsSjgvdlQ1bGxiYUdXR0hZCkRwT0w5cHFaUUp5Zk8yMUxhSjlj
-            UDJ1MjY3M1d1MzEreENsTUpiSzErSlkKLS0tICtETVRpdWptcTVsMklrQ1lYTHBI
-            K0ZVOEFOOEtWYjhlYWZFdzZwTVRnZVUK8KOg9TVzfnyYZvwQ0VUttBA++4QUznzu
-            bvc0I7RvChRqVRfDgvjkQAQug3EEikLl+IWQKXqxGcRzk9dHIvRCxA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxYUsvcnpyOXZHeUhvbW9u
+            Z1ZHbVpKMC94SjVuVi9NNHFJdnU2SVdCa3lnCkJKanloVExtZ1N5cWpXYzNkbVlu
+            WXFKNGY4Tms5S003enFhTUNoOSsvQ2MKLS0tIFh5Mm1aVm01bDQ4QnBkek0wRkdS
+            dXlKMVFYMS8zcXdLTU45YUkzZ0dFR3cKDqyfdDOnvjRBk22NlAwFRm26nhHXGVI0
+            29URCPz7wlz98sUL7bExf4abIVgSQvqV2wgKELAoxQQhciQdBf3hFQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-02T06:08:40Z"
-    mac: ENC[AES256_GCM,data:UJvLLVeHBx6XDBA/FlJ8pyVIw/aDqhq5VGCX1GGYbM9KeluWTywp+dczMau04U6UndpkSVvgOLeNrAurrvVAZkVi+6yWvy194fGqVuXNFqd8nhuReqLpkWtDdoY63weMkFpr3LcvjOw/JFXeB1CWgmgfuZZQX/CIzXVmN2f7duM=,iv:Axh24jdzzwkcanLbF6VcM984+XP9g2MmSjLLf5OLMco=,tag:ASB8N2pnxnzyvSx2b+OXGQ==,type:str]
+    lastmodified: "2026-05-04T16:14:13Z"
+    mac: ENC[AES256_GCM,data:0jegGAyBsFYfm0b7T9LVXkdRJnoDG0zqlFlpfY5a5k9s814qHsPpXoXE4cQywbVeTZAU8xzB6q+Fe16zPSGc9YN20UiKtSGZOyjKIqjboD2G4fmWkibv9/xMc+2FAXtvc6/cJV1ozQWBxVdFkpNpKPGwHuiIcfYle7H0bBBaiVk=,iv:FD+zHydMxpj7Nh+u5zbGSxR/Gnet5kX7zT0ZFCtmqYw=,tag:YO4lgiG0cJDV7J5IP8v00Q==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.12.2

--- a/nextcloud-dev/values.yaml
+++ b/nextcloud-dev/values.yaml
@@ -48,13 +48,13 @@ nextcloud:
     s3:
       enabled: true
       region: ap-northeast-1
+      host: s3.ap-northeast-1.wasabisys.com
+      bucket: trap-nextcloud-dev
       usePathStyle: true
       existingSecret: nextcloud-s3
       secretKeys:
-        host: host
         accessKey: accessKey
         secretKey: secretKey
-        bucket: bucket
 
 persistence:
   enabled: true

--- a/nextcloud-dev/values.yaml
+++ b/nextcloud-dev/values.yaml
@@ -1,0 +1,104 @@
+image:
+  registry: ghcr.io
+  repository: traptitech/nextcloud
+  tag: 29.0.4
+
+nextcloud:
+  host: drive-dev.trapti.tech
+  trustedDomains:
+    - drive-dev.trapti.tech
+  existingSecret:
+    enabled: true
+    secretName: nextcloud-secrets
+    smtpUsernameKey: smtp-username
+    smtpPasswordKey: smtp-password
+    smtpHostKey: smtp-host
+  extraEnv:
+    - name: NEXTCLOUD_TABLE_PREFIX
+      value: "oc_"
+    - name: OVERWRITECLIURL
+      value: "https://drive-dev.trapti.tech"
+    - name: NC_activity_expire_days
+      value: "30"
+    - name: NC_trashbin_retention_obligation
+      value: "7, 30"
+    - name: NC_secret
+      valueFrom:
+        secretKeyRef:
+          name: nextcloud-secrets
+          key: nc_secret
+    - name: NC_passwordsalt
+      valueFrom:
+        secretKeyRef:
+          name: nextcloud-secrets
+          key: nc_passwordsalt
+    - name: NC_instanceid
+      valueFrom:
+        secretKeyRef:
+          name: nextcloud-secrets
+          key: nc_instanceid
+
+  mail:
+    enabled: true
+    fromAddress: drive.system
+    domain: trap.jp
+    smtp:
+      secure: ssl
+  objectStore:
+    s3:
+      enabled: true
+      region: ap-northeast-1
+      usePathStyle: true
+      existingSecret: nextcloud-s3
+      secretKeys:
+        host: host
+        accessKey: accessKey
+        secretKey: secretKey
+        bucket: bucket
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+resources:
+  limits:
+   cpu: 500m
+   memory: 256Mi
+  requests:
+   cpu: 50m
+   memory: 128Mi
+
+cronjob:
+  enabled: true
+  type: sidecar
+  sidecar:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+
+internalDatabase:
+  enabled: false
+
+externalDatabase:
+  enabled: true
+  type: mysql
+  host: tailscale.kmbk.tokyotech.org:33060
+  user: nextcloud
+  database: service_drive_dev
+  existingSecret:
+    enabled: true
+    secretName: nextcloud-db
+    usernameKey: username
+    passwordKey: password
+
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: true
+    existingSecret: nextcloud-redis
+    existingSecretPasswordKey: password

--- a/nextcloud-dev/values.yaml
+++ b/nextcloud-dev/values.yaml
@@ -3,6 +3,16 @@ image:
   repository: traptitech/nextcloud
   tag: 29.0.4
 
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - las211.tokyotech.org
+
 nextcloud:
   host: drive-dev.trapti.tech
   trustedDomains:
@@ -102,3 +112,13 @@ redis:
     enabled: true
     existingSecret: nextcloud-redis
     existingSecretPasswordKey: password
+  master:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: In
+                  values:
+                    - las211.tokyotech.org

--- a/sakura-applications/application-set.yaml
+++ b/sakura-applications/application-set.yaml
@@ -82,6 +82,9 @@ spec:
 
           # portal
           - path: "portal-dev"
+
+          # nextcloud
+          - path: "nextcloud-dev"
   template:
     metadata:
       name: "{{.path.basename}}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Nextcloud 開発環境のデプロイ構成を追加（Helm values と kustomize）
  * TLS 証明書と Ingress ルーティングを追加しホスト名でのセキュアなアクセスを有効化
  * SOPS/Age 暗号化シークレットを追加（DB/Redis/S3/Nextcloud secrets）
  * 外部DB・Redis・S3 設定や cronjob サイドカーの運用パラメータを反映
* **運用**
  * ApplicationSet を更新して nextcloud-dev をデプロイ対象に追加、ksops ジェネレータを有効化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->