### PR TITLE
grafana-backup-workflow-template-patch.yamlにtoletrationsの設定を追加

### DIFF
--- a/monitor/backup/grafana-backup-workflow-template.yaml
+++ b/monitor/backup/grafana-backup-workflow-template.yaml
@@ -37,3 +37,9 @@ spec:
             name: keys
           - mountPath: /data
             name: data
+
+      tolerations:
+        - key: monitor-node
+          operator: Equal
+          value: "true"
+          effect: NoSchedule

--- a/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
+++ b/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
@@ -35,3 +35,9 @@ spec:
             name: keys
           - mountPath: /data
             name: data
+
+      tolerations:
+        - key: monitor-node
+          operator: Equal
+          value: "true"
+          effect: NoSchedule


### PR DESCRIPTION
#1414 が失敗していた問題を解決
https://github.com/traPtitech/manifest/blob/main/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml に #1521 と同様の設定を追加


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Kubernetesスケジューリング設定を更新し、指定されたノードへのワークフローPodのスケジューリングに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->