### PR TITLE
一時的にnextcloud-devを削除

### DIFF
--- a/sakura-applications/application-set.yaml
+++ b/sakura-applications/application-set.yaml
@@ -86,6 +86,7 @@ spec:
 
           # nextcloud
           - path: "nextcloud-dev"
+            exclude: true # 一時的に除外
   template:
     metadata:
       name: "{{.path.basename}}"


### PR DESCRIPTION
一回一からやり直したい

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境設定を更新しました。ポータル開発領域で特定のディレクトリが自動アプリケーション生成から一時的に除外されるよう設定されました。この除外により、当該ディレクトリは自動展開プロセスの対象外となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->