### PR TITLE
LiteLLMに部室サーバーのモデルを追加

### DIFF
--- a/litellm/config/config.yaml
+++ b/litellm/config/config.yaml
@@ -84,6 +84,10 @@ model_list:
       input_cost_per_token: 0.0000005
       output_cost_per_token: 0.000003
       cache_read_input_token_cost: 0.0000001
+  - model_name: gemma-4-e2b
+    litellm_params:
+      model: "ollama_chat/gemma4:e2b"
+      api_base: "http://10.129.106.70:11434"
 litellm_settings:
   num_retries: 3
   request_timeout: 60

--- a/litellm/deployment.yaml
+++ b/litellm/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: litellm
 spec:
-  serviceAccountName: litellm
   selector:
     matchLabels:
       app: litellm
@@ -14,6 +13,7 @@ spec:
       labels:
         app: litellm
     spec:
+      serviceAccountName: litellm
       nodeSelector:
         kubernetes.io/hostname: e505.tokyotech.org
       containers:

--- a/litellm/deployment.yaml
+++ b/litellm/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: litellm
 spec:
+  serviceAccountName: litellm
   selector:
     matchLabels:
       app: litellm
@@ -38,6 +39,31 @@ spec:
           args:
             - "--config"
             - "/app/config.yaml"
+        - name: tailscale-sidecar
+          image: ghcr.io/tailscale/tailscale:v1.96.5
+          securityContext:
+            privileged: true
+          env:
+            - name: TS_USERSPACE
+              value: "false"
+            - name: TS_KUBE_SECRET
+              value: "litellm-tailscale"
+            - name: TS_EXTRA_ARGS
+              value: "--login-server=https://room-vpn.trap.jp --accept-routes"
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: room-vpn-credential
+                  key: TS_AUTHKEY
+                  optional: true
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
       volumes:
         - name: config-volume
           configMap:

--- a/litellm/deployment.yaml
+++ b/litellm/deployment.yaml
@@ -55,7 +55,6 @@ spec:
                 secretKeyRef:
                   name: room-vpn-credential
                   key: TS_AUTHKEY
-                  optional: true
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/litellm/ksops.yaml
+++ b/litellm/ksops.yaml
@@ -13,3 +13,4 @@ files:
   - ./secrets/postgres-config.enc.yaml
   - ./secrets/master-key.enc.yaml
   - ./secrets/fireworks-api-key.enc.yaml
+  - ./secrets/room-vpn-credential.enc.yaml

--- a/litellm/kustomization.yaml
+++ b/litellm/kustomization.yaml
@@ -3,6 +3,9 @@ resources:
   - ./service.yaml
   - ./ingress-route.yaml
   - ./certificate.yaml
+  - ./serviceaccount.yaml
+  - ./tailscale-role.yaml
+  - ./tailscale-rolebinding.yaml
 
 configMapGenerator:
   - name: litellm-config-file

--- a/litellm/secrets/room-vpn-credential.enc.yaml
+++ b/litellm/secrets/room-vpn-credential.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: room-vpn-credential
+    annotations:
+        kustomize.config.k8s.io/needs-hash: "true"
+stringData:
+    TS_AUTHKEY: ENC[AES256_GCM,data:Rfmly4lIXD3uPqOAan5d2YsznZepSKE5B7vTvZN1hkRoM1XS5+VGHbgTRCI6plx6AVhGz0p0k5fDW7LHJAbmt4WIsI0I0OiVVaXLXLPn4T9REhH0pvOnfw==,iv:J6YT6Xu51l9B+JiUjHDoSWJMOffRl0pgKF2760WfNKk=,tag:j4yXMm1lPQDjJcGNvvO5/A==,type:str]
+sops:
+    age:
+        - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArQ3NoMktKeTd6OVA2VjZM
+            eCs3VGJETy9IYU03ckZBdmR2TDhRTzYrWWhnClF3bGMrRzJiU0taMnNSQlE1UmtU
+            Z29UaUZMY1UyaGlkbkVhcVBodVFDZVEKLS0tIEY5UzYwbW5IbzltUDA0Nk0rUFZy
+            UTRTQmVHRWlYYlpCMUFDaUVLYWRMU3cK5K+E28xnjAvjavTFPiDYJ+mhJDA7cv6x
+            ZnzIJEOhqSydYYQBPHk4Y1zF5Svbi5OLqXG87KBprexHeW6eV820Sg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-08T06:05:48Z"
+    mac: ENC[AES256_GCM,data:tGuEq2OROkoXxrjpKNbefxukj+fyM2PJ198jzYIlAoxu8avZ2vo645G5ZWJhul4G542BxYn0PtP8adhE0SpxmeTkaEnN+/rMfMwQ2nEgPG7e1G/g4DUsNQuMQbZN/f+n6oetZz9GDeNdYO9J5WLEGqfhJpSrxFrUyM/QufelvNY=,iv:wneTtfpVRyiI67F/jXb1iOdIEY29MQLut1WyfkUl46U=,tag:pU/v5pJ2c0Y1Ikweikk7iw==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.11.0

--- a/litellm/serviceaccount.yaml
+++ b/litellm/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: litellm

--- a/litellm/tailscale-role.yaml
+++ b/litellm/tailscale-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resourceNames: ["litellm-tailscale"]
+    resources: ["secrets"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "create", "patch"]

--- a/litellm/tailscale-role.yaml
+++ b/litellm/tailscale-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: tailscale
+  name: litellm-tailscale
 rules:
   - apiGroups: [""]
     resources: ["secrets"]

--- a/litellm/tailscale-rolebinding.yaml
+++ b/litellm/tailscale-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: litellm-tailscale
+subjects:
+  - kind: ServiceAccount
+    name: litellm
+roleRef:
+  kind: Role
+  name: litellm-tailscale
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
LiteLLMをroom-vpnに接続し、部室サーバー上のOllamaモデルを追加
preauthkey生成コマンド: `kubectl exec headscale-0 -n room-vpn -- headscale preauthkey create -u 2 --ephemeral -e 100y --reusable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しいモデル `gemma-4-e2b` を利用可能にしました。

* **その他**
  * デプロイメントのセキュリティとネットワーク接続を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->