### PR TITLE
feat(nextcloud-dev): 環境変数を設定

### DIFF
--- a/nextcloud-dev/config.yaml
+++ b/nextcloud-dev/config.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-env
+data:
+  REDIS_HOST: valkey
+  NC_redis_user: default
+  OBJECT_STORE_S3_BUCKET: trap-nextcloud-dev
+  OBJECT_STORE_S3_REGION: ap-northeast-1
+  OBJECT_STORE_S3_HOST: s3.ap-northeast-1.wasabisys.com
+  OBJECT_STORE_S3_PORT: "443"
+  OBJECT_STORE_S3_AUTOCREATE: "false"
+  OBJECT_STORE_S3_USEPATH_STYLE: "true"
+  SMTP_HOST: smtp.sendgrid.host
+  SMTP_SECURE: ssl
+  SMTP_NAME: apikey
+  MAIL_FROM_ADDRESS: drive.system
+  MAIL_DOMAIN: trap.jp
+  OVERWRITECLIURL: https://drive-dev.trapti.tech
+  NC_dbtype: mysql
+  NC_dbname: service_drive_dev
+  NC_dbhost: tailscale.kmbk.tokyotech.org
+  NC_dbport: "33060"
+  NC_dbuser: service_drive_dev
+  NC_dbtableprefix: oc_
+  NC_mysql.utf8mb4: "true"
+  NC_trusted_domains: drive-dev.trapti.tech

--- a/nextcloud-dev/config.yaml
+++ b/nextcloud-dev/config.yaml
@@ -5,12 +5,12 @@ metadata:
 data:
   REDIS_HOST: valkey
   NC_redis_user: default
-  OBJECT_STORE_S3_BUCKET: trap-nextcloud-dev
-  OBJECT_STORE_S3_REGION: ap-northeast-1
-  OBJECT_STORE_S3_HOST: s3.ap-northeast-1.wasabisys.com
-  OBJECT_STORE_S3_PORT: "443"
-  OBJECT_STORE_S3_AUTOCREATE: "false"
-  OBJECT_STORE_S3_USEPATH_STYLE: "true"
+  OBJECTSTORE_S3_BUCKET: trap-nextcloud-dev
+  OBJECTSTORE_S3_REGION: ap-northeast-1
+  OBJECTSTORE_S3_HOST: s3.ap-northeast-1.wasabisys.com
+  OBJECTSTORE_S3_PORT: "443"
+  OBJECTSTORE_S3_AUTOCREATE: "false"
+  OBJECTSTORE_S3_USEPATH_STYLE: "true"
   SMTP_HOST: smtp.sendgrid.host
   SMTP_SECURE: ssl
   SMTP_NAME: apikey

--- a/nextcloud-dev/deployment.yaml
+++ b/nextcloud-dev/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             requests:
               cpu: 50m
               memory: 128Mi
+          envFrom:
+            - configMapRef:
+                name: config-env
+            - secretRef:
+                name: secret-env
           volumeMounts:
             - mountPath: /var/www/
               name: nextcloud-main
@@ -136,6 +141,11 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+          envFrom:
+            - configMapRef:
+                name: config-env
+            - secretRef:
+                name: secret-env
           volumeMounts:
             - mountPath: /var/www/
               name: nextcloud-main

--- a/nextcloud-dev/deployment.yaml
+++ b/nextcloud-dev/deployment.yaml
@@ -40,6 +40,12 @@ spec:
             requests:
               cpu: 50m
               memory: 128Mi
+          env:
+            - name: REDIS_HOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: valkey
+                  key: default
           envFrom:
             - configMapRef:
                 name: config-env
@@ -141,6 +147,12 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+          env:
+            - name: REDIS_HOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: valkey
+                  key: default
           envFrom:
             - configMapRef:
                 name: config-env

--- a/nextcloud-dev/secrets/secret-env.enc.yaml
+++ b/nextcloud-dev/secrets/secret-env.enc.yaml
@@ -3,26 +3,25 @@ kind: Secret
 metadata:
     name: valkey
 stringData:
-    REDIS_HOST_PASSWORD: ENC[AES256_GCM,data:qSsMBoBN3h1zRx4OQ4orFt902HknwJPI,iv:xhkfKAVSKEAKnGp+W/XbaLyKT3cBC97TtnVOZN72iI8=,tag:sb93RH2P/3nMyglBt2MqCA==,type:str]
-    OBJECTSTORE_S3_KEY: ENC[AES256_GCM,data:BKtFrw3xjo6ypjvfnJfueA+aKBY=,iv:vKdzVVcgaTD/nOavPiTS0uT03MfDpH+e1yOuI2zQzpA=,tag:JSJdRFdZrWMz5Z33L4MUsg==,type:str]
-    OBJECTSTORE_S3_SECRET: ENC[AES256_GCM,data:z+MUzS4wWnANugzihpmQbGVOR1EfG3e+hunAb/+qWVrqwVwIet3Kiw==,iv:hYFFWoAowGNJLKyy9JBhNCSXtd0DLNnD8C0mw2AnM9U=,tag:4P/oLTHwIJraEzFVPxq+KQ==,type:str]
-    SMTP_PASSWORD: ENC[AES256_GCM,data:hJaAv1bZakQZ77AhzlGKVCpBJmN917IlMFXcATPE7f/4LGtHh/AwntroArpxDBevvYMSli/ntlcM2AkPdppHUvdWmsN6,iv:9twAoVqrqJ4fVN60cdUmdY96puGJh41/6JNRnC/3VAk=,tag:hC4fFCoFH7jdsvO0d2NiYw==,type:str]
-    NC_dbpassword: ENC[AES256_GCM,data:T+49GoGP7AvCQdlz+LRNu+1+KYxxaXJHLTaiHsbS/hxYZ8+yrO299tt8Wb4+rILxYAT9sn0PiBBaENWDjN1wCA==,iv:+18tqpbsrxJnTKnM6udxA9pU+Ye3+nV44Wx3Xp+9+RA=,tag:rIC5CY5/GASLvtLEsx+xTg==,type:str]
-    NC_passwordsalt: ENC[AES256_GCM,data:UgQIwg2n63p2LeV2xE1xfiy7QPyJIPxHH7Nj+pdw,iv:P6ALA377wiLv0KGL85FPpo2npt17xownTipuvjKbvJo=,tag:WZUEuyKMctp/3h3nSP/d6A==,type:str]
-    NC_secret: ENC[AES256_GCM,data:6ncHJxxTcZL69WU05azEZetqkoyQ0L8zMpVbhDL+hqmx5Z67EhFzMXfL9m7Flm5O,iv:2YY4ujS2qHQM6er2QxggL3cuhDWVYBjz3Rk+fiMgCDo=,tag:NY//KornuI1rmOfZW0674A==,type:str]
-    NC_instanceid: ENC[AES256_GCM,data:AT+0O16HiVGJh+GX,iv:xWOnEBz1bVqgO4Nc8mBXJA5Q+fbVuYArw6BvHDChf9A=,tag:mqz1YufGieViYQQg/uHQug==,type:str]
+    OBJECTSTORE_S3_KEY: ENC[AES256_GCM,data:8g/Nv6xJYmk98j1vJ27kzv0bI64=,iv:K76YbRfNV+dxNGlP8Siz/wRqNlpFg6SvbmCGx8xuha8=,tag:jeR9ieWHYDros0hj5Nn/Nw==,type:str]
+    OBJECTSTORE_S3_SECRET: ENC[AES256_GCM,data:V91Qu9TAqeFqZHWWxwj7egrZZ8Pe+uTe+xKKhCKA92y6exY4Kzx2Fg==,iv:4igvBvedhCUcD6mYT8oakvSw565auDc5EPtJfD37iiE=,tag:aGNkCujtnMUBhAoQzDW7sQ==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:LpAiQspReHYL1XkLVVHD/dyWw76sSFV8X72GOa6z2b4qdf/CkMfiKgBmo/1zNep8LaBYsv0Ia/jRFW7O2Hr0mPVxLWlR,iv:KLJYWUk2FZlBVu7ObeFx4S799LQxG4a66J0PL7SPyRY=,tag:D7EDk7iCHA7xnd4REuCe2Q==,type:str]
+    NC_dbpassword: ENC[AES256_GCM,data:n7Hfp+853pCwBAnkKDls0Xja1tR3wV789a45/1F7qizr2l1mglsmtdDm6aJ8o50H6igjHEM/ZeGVrLbwkop2uQ==,iv:bNs4idJdI5Qougs8Ac9JDdPxMzHcHwHoSBMmZeP2hI4=,tag:fwo4GVrwFeAq8xUYIj7HHg==,type:str]
+    NC_passwordsalt: ENC[AES256_GCM,data:Hmx6tz6+Z/dox6iBAbumqSqePp/oeGtqAop2h2CM,iv:3GW+hdTIQGIilrTcMQ0868twAg5uVxQ0Xqj+VV4jq9w=,tag:uiX/u6mIDEWLtoUIqubsHw==,type:str]
+    NC_secret: ENC[AES256_GCM,data:SlgpqmCgFzbtYRROivTEAe4PzEE2j84hO/Hgyl1XzwbsnNBmThgEuCzEq3vnzsUn,iv:N6jT8h/uc/BivtZIQGey6uEDITRazluDDirpB20xjOg=,tag:hK2fpgnpKimLF0a2475yag==,type:str]
+    NC_instanceid: ENC[AES256_GCM,data:sCbr2taOaGz58YEA,iv:XcbaeU8iT78sUpQXO0ZQB+XtC71Cdk6MFs6fzRG6BsY=,tag:k9ra02Cgt42Pd1oDB0jdwQ==,type:str]
 sops:
     age:
         - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSc0d4ckhhU1dDQTlxS1Uw
-            V2FSY2c3Sk1jRjV6MHRqUkVIcGxUV1o3c2lnCitGYmw1U0JUTmJmeGdzMjZzY2s2
-            V1RoVytpZUJ2aFhRbVlJMXBUbFlFcVkKLS0tIG9SdENwS0E0TjJldk5TSG9xTXVi
-            SDVUc0xVQ084NEE2R0R5bWVvOFduSTQKx7gyd/ZBYuoWKzQeDuM6T/V0XWBqZ0It
-            doq4KnHH3jCsnxL6SJt/XzPNfKLYeNm4ypM/7uz6C8Yf+MusbRti+g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhazFFV2llRzNuZ043ZUlm
+            MzZ0eC91djJxYURITkI4SXQ4TGN5N2g1SFFjCmRNanZpNFJWV2o2Q0lTbXg4eEFU
+            enJFVEJzU1FUblJmbXhPQlBSb29GaDQKLS0tIE92endvNmlpREdXVzEvWE1kYno2
+            amQxK0dKRDN3aEdGKzhXZG5DREhreVkKEce45VjYKJ5MAzT+3vS5OBZ491N/I8Z5
+            u3gWxe3sR3bobuMOyhFALQtRVL1wotP82Exfs/dVonDa/AXVf+FwGg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-09T09:20:04Z"
-    mac: ENC[AES256_GCM,data:Y3YqSLfJ7fPHGIw55pEHh6T2Wmay/aqb8VWZLBSDcwdU7mgFHLvl9xlk50PK3veZh54wbcuEyhp++QOVbwZicApBIzo4mom1t5N9Tir3D0qg9W7bma1gqvMhfKRMYd3+LUgQk85KgRVhl3uUCftbkxtBd5Sw/1rrI9tKAQSxGM0=,iv:sUvjzdKXmi4wPP65GGkHniDn8J3Av3zjLCcUzS7bYio=,tag:ipE/NnggAEyU6y3HV48EPQ==,type:str]
+    lastmodified: "2026-05-09T09:36:55Z"
+    mac: ENC[AES256_GCM,data:fWrZOiECU0iMTSjDw+nI8FoPrRJu4DJ6n1pkmjhokkCW/Beu3GRpAUTE5XK5isNCJRHN+7ruhf5WCFjcytZnVKTbM427nvtTcZd3zpgtBGA7jJ4b6wn7WOofBfoCg0QhxLlXo/fhZJc9JIcV0D2Ery/2ITmN1TRh8L/CalozvBE=,iv:zHIuUfU5ym2jDbsu5c6iHpGN5sWtHLXAlp56D6pwhus=,tag:ueZX8R8uZmi5YntsZpVIQA==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.12.2

--- a/nextcloud-dev/secrets/secret-env.enc.yaml
+++ b/nextcloud-dev/secrets/secret-env.enc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: valkey
+stringData:
+    REDIS_HOST_PASSWORD: ENC[AES256_GCM,data:qSsMBoBN3h1zRx4OQ4orFt902HknwJPI,iv:xhkfKAVSKEAKnGp+W/XbaLyKT3cBC97TtnVOZN72iI8=,tag:sb93RH2P/3nMyglBt2MqCA==,type:str]
+    OBJECTSTORE_S3_KEY: ENC[AES256_GCM,data:BKtFrw3xjo6ypjvfnJfueA+aKBY=,iv:vKdzVVcgaTD/nOavPiTS0uT03MfDpH+e1yOuI2zQzpA=,tag:JSJdRFdZrWMz5Z33L4MUsg==,type:str]
+    OBJECTSTORE_S3_SECRET: ENC[AES256_GCM,data:z+MUzS4wWnANugzihpmQbGVOR1EfG3e+hunAb/+qWVrqwVwIet3Kiw==,iv:hYFFWoAowGNJLKyy9JBhNCSXtd0DLNnD8C0mw2AnM9U=,tag:4P/oLTHwIJraEzFVPxq+KQ==,type:str]
+    SMTP_PASSWORD: ENC[AES256_GCM,data:hJaAv1bZakQZ77AhzlGKVCpBJmN917IlMFXcATPE7f/4LGtHh/AwntroArpxDBevvYMSli/ntlcM2AkPdppHUvdWmsN6,iv:9twAoVqrqJ4fVN60cdUmdY96puGJh41/6JNRnC/3VAk=,tag:hC4fFCoFH7jdsvO0d2NiYw==,type:str]
+    NC_dbpassword: ENC[AES256_GCM,data:T+49GoGP7AvCQdlz+LRNu+1+KYxxaXJHLTaiHsbS/hxYZ8+yrO299tt8Wb4+rILxYAT9sn0PiBBaENWDjN1wCA==,iv:+18tqpbsrxJnTKnM6udxA9pU+Ye3+nV44Wx3Xp+9+RA=,tag:rIC5CY5/GASLvtLEsx+xTg==,type:str]
+    NC_passwordsalt: ENC[AES256_GCM,data:UgQIwg2n63p2LeV2xE1xfiy7QPyJIPxHH7Nj+pdw,iv:P6ALA377wiLv0KGL85FPpo2npt17xownTipuvjKbvJo=,tag:WZUEuyKMctp/3h3nSP/d6A==,type:str]
+    NC_secret: ENC[AES256_GCM,data:6ncHJxxTcZL69WU05azEZetqkoyQ0L8zMpVbhDL+hqmx5Z67EhFzMXfL9m7Flm5O,iv:2YY4ujS2qHQM6er2QxggL3cuhDWVYBjz3Rk+fiMgCDo=,tag:NY//KornuI1rmOfZW0674A==,type:str]
+    NC_instanceid: ENC[AES256_GCM,data:AT+0O16HiVGJh+GX,iv:xWOnEBz1bVqgO4Nc8mBXJA5Q+fbVuYArw6BvHDChf9A=,tag:mqz1YufGieViYQQg/uHQug==,type:str]
+sops:
+    age:
+        - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSc0d4ckhhU1dDQTlxS1Uw
+            V2FSY2c3Sk1jRjV6MHRqUkVIcGxUV1o3c2lnCitGYmw1U0JUTmJmeGdzMjZzY2s2
+            V1RoVytpZUJ2aFhRbVlJMXBUbFlFcVkKLS0tIG9SdENwS0E0TjJldk5TSG9xTXVi
+            SDVUc0xVQ084NEE2R0R5bWVvOFduSTQKx7gyd/ZBYuoWKzQeDuM6T/V0XWBqZ0It
+            doq4KnHH3jCsnxL6SJt/XzPNfKLYeNm4ypM/7uz6C8Yf+MusbRti+g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-09T09:20:04Z"
+    mac: ENC[AES256_GCM,data:Y3YqSLfJ7fPHGIw55pEHh6T2Wmay/aqb8VWZLBSDcwdU7mgFHLvl9xlk50PK3veZh54wbcuEyhp++QOVbwZicApBIzo4mom1t5N9Tir3D0qg9W7bma1gqvMhfKRMYd3+LUgQk85KgRVhl3uUCftbkxtBd5Sw/1rrI9tKAQSxGM0=,iv:sUvjzdKXmi4wPP65GGkHniDn8J3Av3zjLCcUzS7bYio=,tag:ipE/NnggAEyU6y3HV48EPQ==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.12.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Nextcloud デプロイメント環境設定をKubernetes ConfigMapおよびSecretを通じて一元管理するように改善しました。Redis、S3互換ストレージ、SMTP、データベース接続などの設定を環境変数で統合管理できるようになりました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1591)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->