### PR TITLE
feat:traQを`arc321.tokyotech.org`へ移行

### DIFF
--- a/applications/application-set.yaml
+++ b/applications/application-set.yaml
@@ -81,6 +81,8 @@ spec:
             exclude: true
           - path: "nextcloud-dev"
             exclude: true
+          - path: "traq"
+            exclude: true
   template:
     metadata:
       name: "{{.path.basename}}"

--- a/sakura-applications/application-set.yaml
+++ b/sakura-applications/application-set.yaml
@@ -89,6 +89,9 @@ spec:
 
           # nextcloud
           - path: "nextcloud-dev"
+
+          # traq
+          - path: "traq"
   template:
     metadata:
       name: "{{.path.basename}}"

--- a/traq/backend/config/traq.yaml
+++ b/traq/backend/config/traq.yaml
@@ -13,7 +13,7 @@ firebase:
     file: /keys/service-account.json
 
 es:
-  url: http://private.e505.tokyotech.org:9201
+  url: http://es:9200
   username: elastic
   # password: <env secret>
 
@@ -26,7 +26,7 @@ gcp:
       enabled: false
 
 mariadb:
-  host: private.kmbk.tokyotech.org
+  host: tailscale.kmbk.tokyotech.org
   port: 3306
   username: service_traq_r
   # password: <env secret>

--- a/traq/backend/deployment.yaml
+++ b/traq/backend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         pyroscope.io/port: "6060"
     spec:
       nodeSelector:
-        kubernetes.io/hostname: c1-203.tokyotech.org
+        kubernetes.io/hostname: arc321.tokyotech.org
       volumes:
         - name: config
           configMap:

--- a/traq/backend/ksops.yaml
+++ b/traq/backend/ksops.yaml
@@ -1,11 +1,11 @@
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:
-   name: ksops
-   annotations:
-      config.kubernetes.io/function: |
-         exec:
-           path: ksops
+  name: ksops
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
 
 files:
   - ./secrets/secrets.enc.yaml

--- a/traq/es/statefulset.yaml
+++ b/traq/es/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       enableServiceLinks: false
       nodeSelector:
-        kubernetes.io/hostname: arc321.tokyotech.org
+        kubernetes.io/hostname: las211.tokyotech.org
 
       volumes:
         - name: data

--- a/traq/es/statefulset.yaml
+++ b/traq/es/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
 
       volumes:
         - name: data
-          # hostPathやめたい
+          # TODO:hostPathやめたい
           hostPath:
             path: /opt/elasticsearch/traq-data
             type: DirectoryOrCreate
@@ -34,7 +34,7 @@ spec:
 
       containers:
         - name: es
-          # elasticsearchとsudachiのバージョン上げたい
+          # TODO:elasticsearchとsudachiのバージョン上げたい
           image: ghcr.io/traptitech/es-with-sudachi:8.8.1-3.1.0
           env:
             - name: discovery.type

--- a/traq/es/statefulset.yaml
+++ b/traq/es/statefulset.yaml
@@ -20,10 +20,11 @@ spec:
     spec:
       enableServiceLinks: false
       nodeSelector:
-        kubernetes.io/hostname: e505.tokyotech.org
+        kubernetes.io/hostname: arc321.tokyotech.org
 
       volumes:
         - name: data
+          # hostPathやめたい
           hostPath:
             path: /opt/elasticsearch/traq-data
             type: DirectoryOrCreate
@@ -33,6 +34,7 @@ spec:
 
       containers:
         - name: es
+          # elasticsearchとsudachiのバージョン上げたい
           image: ghcr.io/traptitech/es-with-sudachi:8.8.1-3.1.0
           env:
             - name: discovery.type
@@ -43,11 +45,8 @@ spec:
                   name: es-password
                   key: es-password
           ports:
-            # for compatibility with old infra; TODO: remove old host port expose
             - name: es
               containerPort: 9200
-              hostIP: 192.168.0.12
-              hostPort: 9201
           volumeMounts:
             - mountPath: /usr/share/elasticsearch/data
               name: data

--- a/traq/es/statefulset.yaml
+++ b/traq/es/statefulset.yaml
@@ -34,8 +34,7 @@ spec:
 
       containers:
         - name: es
-          # TODO:elasticsearchとsudachiのバージョン上げたい
-          image: ghcr.io/traptitech/es-with-sudachi:8.8.1-3.1.0
+          image: ghcr.io/traptitech/es-with-sudachi:8.17.10-3.5.0
           env:
             - name: discovery.type
               value: single-node

--- a/traq/frontend/deployment.yaml
+++ b/traq/frontend/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app: traq-frontend
   name: traq-frontend
+
 spec:
   replicas: 1
   selector:
@@ -15,7 +16,7 @@ spec:
         app: traq-frontend
     spec:
       nodeSelector:
-        kubernetes.io/hostname: c1-203.tokyotech.org
+        kubernetes.io/hostname: arc321.tokyotech.org
       containers:
         - image: ghcr.io/traptitech/traq-ui:3.31.3
           name: traq-frontend

--- a/traq/frontend/ingress-route.yaml
+++ b/traq/frontend/ingress-route.yaml
@@ -11,6 +11,7 @@ spec:
   routes:
     - kind: Rule
       match: Host(`q.trap.jp`)
+      # なぜ`-100`が設定されているのかがわからない
       priority: -100
       services:
         - namespace: traq

--- a/traq/frontend/ingress-route.yaml
+++ b/traq/frontend/ingress-route.yaml
@@ -11,8 +11,6 @@ spec:
   routes:
     - kind: Rule
       match: Host(`q.trap.jp`)
-      # なぜ`-100`が設定されているのかがわからない
-      priority: -100
       services:
         - namespace: traq
           kind: Service

--- a/traq/system-bot/deployment.yaml
+++ b/traq/system-bot/deployment.yaml
@@ -16,6 +16,8 @@ spec:
     spec:
       enableServiceLinks: false
       automountServiceAccountToken: false
+      nodeSelector:
+        kubernetes.io/hostname: arc321.tokyotech.org
       containers:
         - name: system-bot
           image: ghcr.io/traptitech/traq-system-bot:1.1.0

--- a/traq/widget/deployment.yaml
+++ b/traq/widget/deployment.yaml
@@ -4,18 +4,21 @@ metadata:
   labels:
     app: traq-widget
   name: traq-widget
+
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: traq-widget
+
   template:
     metadata:
       labels:
         app: traq-widget
+
     spec:
       nodeSelector:
-        kubernetes.io/hostname: c1-203.tokyotech.org
+        kubernetes.io/hostname: arc321.tokyotech.org
       containers:
         - image: ghcr.io/traptitech/traq-widget:0.3.7
           name: traq-widget


### PR DESCRIPTION
さくらのVPSへの移行のために`arc321.tokyotech.org`への移行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 複数サービスのノード割り当てを更新しました。
  * 検索サービスとデータベースの接続先ホストを更新しました。
  * デプロイ対象となるリポジトリ内ディレクトリの追加／除外設定を調整しました。

* **Style**
  * YAML のフォーマットと注釈を整理・追記しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->