### PR TITLE
fix: ExternalNameServiceを有効にした

### DIFF
--- a/traefik/config/traefik.yaml
+++ b/traefik/config/traefik.yaml
@@ -17,6 +17,7 @@ metrics:
 
 providers:
   kubernetesCRD:
+    allowExternalNameServices: true
     allowCrossNamespace: true
     allowEmptyServices: true
   kubernetesIngress: {}


### PR DESCRIPTION
デフォルトでFalseになっていて、codimdではこれを使いたいので有効化しました
https://doc.traefik.io/traefik/reference/install-configuration/providers/kubernetes/kubernetes-crd/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Kubernetes CRDプロバイダーで外部名サービスのサポートを有効化しました。これにより、Traefikはクラスタ外のサービスへのルーティングをより柔軟に処理できるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->