### PR TITLE
mig: mdの本番環境を移行

### DIFF
--- a/sakura-applications/application-set.yaml
+++ b/sakura-applications/application-set.yaml
@@ -78,9 +78,9 @@ spec:
           - path: "poll"
 
           # codimd
-          # - path: "codimd"
+          - path: "codimd"
           - path: "codimd-dev"
-          
+
           # CPCTF スコアサーバーメンテナンスページ
           - path: "cpctf-maint"
 


### PR DESCRIPTION
application-setのコメントアウトを外します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * `codimd` および `codimd-dev` アプリケーションの自動デプロイメント設定を有効化しました。Argo CDが両アプリケーションを自動で生成・管理するようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->