### PR TITLE
feat: litellmの移行の準備 (#1614)のやり直し

### DIFF
--- a/applications/application-set.yaml
+++ b/applications/application-set.yaml
@@ -87,6 +87,8 @@ spec:
             exclude: true
           - path: "nextcloud-dev"
             exclude: true
+          - path: "litellm"
+            exclude: true
           - path: "traq-dev"
             exclude: true
 

--- a/litellm/deployment.yaml
+++ b/litellm/deployment.yaml
@@ -13,8 +13,16 @@ spec:
       labels:
         app: litellm
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: e505.tokyotech.org
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - las211.tokyotech.org
+              weight: 1
       containers:
         - name: litellm
           image: ghcr.io/berriai/litellm:v1.82.3-stable.patch.2

--- a/litellm/secrets/postgres-config.enc.yaml
+++ b/litellm/secrets/postgres-config.enc.yaml
@@ -5,24 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/needs-hash: "true"
 stringData:
-    DATABASE_URL: ENC[AES256_GCM,data:NRnlh8o8XtACpDR/NjuuKb+xOZZcJawmnBYJRWVq+v1nPFFDECpCk6BtefE2CXQcTpguSDaqmtCernhLHhS2ktrmg71fkVp74qV7vkl5A9/B9iyZrruMLodA3+9D5zBxZ6ZtPLt/3foxPZiwvVZmw+JDpe1GjWhOQR/uoYguNCoNPJhlSVH7JxVg,iv:wyOnS7+JYNOyTw7nR0Gii43xmoz0tGXQ6EFSPlPlw+g=,tag:HtmTHsPW+znEjifiORAVCQ==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:5kwruJJJx/PQF1F8cyDdvZTPZiqIrDclHfIvZiQ7sITLJl3dsge2LyLplnMXrg1iyb8neW27hJ2bazYn5zn9cC15C08dcqi49ieQYYNM8f524jVy7X0Gi1NEzfwseI7GQqZb9vK6wbx8clUuaBpr4CayF3lO+plyCSjnC5PV61DmIsBbxKz1BH2XgPY=,iv:6XjwJIbg1Ftu5I9ylmg2spPdOmEy0FhETMr7ZYbszd0=,tag:QrroAggPJjXVUYxgS34law==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmYXJOcUJ5MWV3aXgvc0E0
-            c0dIMDVPMHUraVNhVW9DQ3o3aWM0MHRvdFdZCnRuRUpQQ0lxR3FTb3hZMFRBU2Rv
-            N1BJOGRuZk8xU0puZjJCNm0wTlV1UG8KLS0tIFlPVXpmekpEZkxtejRkQ1pIdlBC
-            enkzRUtMcStSVnFBVVEwR1JYQUhUakEK+P7WZJAV1zMSScZpsOnADHOKtcexbKCN
-            j24CpBxa9ARDJILLo4GJ6DDg0Bzx4mGbiOGZahGYmO8bBRFuiIrttw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFWlFxWTQ5MldlSGgwcDFZ
+            N2dFMTBvRFZOQS81TkRqNlRjOEpKVnlPUjFZCjVtQk1BdlBzOTA2T3NxWlMxUVRK
+            VUxIRXFTc2lyOTgweXJrQUlUNnhraGsKLS0tIHhoWCt2UlNuSlY2ZDlxT3gwVTY5
+            eDQzSkh0YjFUMDVCTDMraGcvN3l6V0EKB19oJnjAsEHbclpItAJ8DjaUAnKaee4E
+            BDN85t2dsKQdADce4I5Mxtt6pfVZClMD+1tmlagKj5FCdGTW3XQOgg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-04-04T11:39:15Z"
-    mac: ENC[AES256_GCM,data:hJFweoCtUHAHg4igR+N3vTmozzVDpV6njKT/hIncjisiaTlbvO9RxznSe0i5hMIdk7Lv33BWMfwugabjNzi+NSlSP/sFXfsrI4uIldIkRSBMxYBG2tMeMZmXQRiH4qHnpETbMfAFVlMqHCURT6Twke2ZMxu36A+i0JntJ5IWUGI=,iv:6HAhLDppqk6oMnjS6Vr8T4Sadh4psv4sNMcRo0YV6OY=,tag:2WtL7WG7GQuu7Wj16RxX/Q==,type:str]
-    pgp: []
+    lastmodified: "2026-05-18T15:32:15Z"
+    mac: ENC[AES256_GCM,data:UDLtN2yZF9IP7MfjEX9yZaNWbUuLuUzm7dLtbygKSuDkTYqVi2Iik61UFyGfl6YvBDtX/Kycn81a96AUAt1CJ8M1CVhI9GRCOOTpSiNxYmZ5Padw3aYfufJG/P10uXE6Lz5v1Hz2GROoXGWxtyZrojVX4sMlhGcOfH+UQnBI4KA=,iv:Mdn7OJbVaTj4Q6rvMJQwXRcTozo8JefgxJf4xBcgrKk=,tag:8GFKgrwbfi+ItAemODs6NQ==,type:str]
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
-    version: 3.9.4
+    version: 3.12.2

--- a/sakura-applications/application-set.yaml
+++ b/sakura-applications/application-set.yaml
@@ -95,6 +95,9 @@ spec:
           - path: "nextcloud"
           - path: "nextcloud-dev"
 
+          # LiteLLM
+          - path: "litellm"
+          
           # traq
           - path: "traq-dev"
 


### PR DESCRIPTION
* feat: litellmの移行の準備

* PostgreSQLのドメインを`tailscale.kmbk.tokyotech.org`に変更

---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ApplicationSet生成設定を更新しました。litellmの配置制御を改善しています。
  * Pod スケジューリングの設定を変更し、ホスト選択方針を柔軟化しました。
  * 暗号化されたデータベース認証情報を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->