### PR TITLE
hotfix:esにアクセスする際にhttpsを使用するように

### DIFF
--- a/traq/backend/config/traq.yaml
+++ b/traq/backend/config/traq.yaml
@@ -13,7 +13,7 @@ firebase:
     file: /keys/service-account.json
 
 es:
-  url: http://es:9200
+  url: https://es:9200
   username: elastic
   # password: <env secret>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Elasticsearch接続スキームをHTTPからHTTPSに更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->