### PR TITLE
gitea-act-runnerをさくらに移行

### DIFF
--- a/applications/application-set.yaml
+++ b/applications/application-set.yaml
@@ -95,6 +95,8 @@ spec:
             exclude: true
           - path: "traq"
             exclude: true
+          - path: "gitea"
+            exclude: true
 
   template:
     metadata:

--- a/gitea/act-runner/act-runner.yaml
+++ b/gitea/act-runner/act-runner.yaml
@@ -86,7 +86,7 @@ spec:
           resources:
             requests:
               cpu: "10m"
-              memory: "100Mi"
+              memory: "128Mi"
             limits:
-              cpu: "1"
-              memory: "150Mi"
+              cpu: "100m"
+              memory: "256Mi"

--- a/gitea/act-runner/gitea-act-runner.yaml
+++ b/gitea/act-runner/gitea-act-runner.yaml
@@ -18,7 +18,7 @@ rules:
     verbs: ["get", "create"]
   - apiGroups: [""]
     resources: ["pods/log"]
-    verbs: ["get", "list", "watch",]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "create", "delete"]
@@ -97,7 +97,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - e505.tokyotech.org
+                      - las211.tokyotech.org
               weight: 1
 
       containers:

--- a/gitea/act-runner/gitea-act-runner.yaml
+++ b/gitea/act-runner/gitea-act-runner.yaml
@@ -132,7 +132,7 @@ spec:
           resources:
             requests:
               cpu: "10m"
-              memory: "500Mi"
+              memory: "64Mi"
             limits:
-              cpu: "1"
-              memory: "600Mi"
+              cpu: "100m"
+              memory: "128Mi"

--- a/sakura-applications/application-set.yaml
+++ b/sakura-applications/application-set.yaml
@@ -80,7 +80,7 @@ spec:
           # codimd
           # - path: "codimd"
           - path: "codimd-dev"
-          
+
           # CPCTF スコアサーバーメンテナンスページ
           - path: "cpctf-maint"
 
@@ -98,10 +98,13 @@ spec:
 
           # LiteLLM
           - path: "litellm"
-          
+
           # traq
           - path: "traq-dev"
           - path: "traq"
+
+          # Gitea
+          - path: "gitea"
   template:
     metadata:
       name: "{{.path.basename}}"


### PR DESCRIPTION
- runner側からGiteaに登録するので、Giteaの設定変更は必要ない
- `gitea-act-runner`stsにはPVCがついているが、
  - `whenDeleted: Delete`のため、自動で削除される
  - PVCになっている目的はrunnerが作成するPodにリポジトリ等を渡すため(らしい)ので、引き継ぐ必要はなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Gitea関連の展開設定を調整しました。一部環境では生成対象から除外され、別環境では対象に含まれるようになります。
  * ノード親和性設定を更新し、実行環境の割り当てを最適化しました。
  * ポッドログへのアクセス制御ルールを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->