### PR TITLE
grafanaのデータをhostPathからPVCに移行

### DIFF
--- a/sakura-monitor/grafana/deployment-patch.yaml
+++ b/sakura-monitor/grafana/deployment-patch.yaml
@@ -4,6 +4,7 @@ metadata:
   name: grafana
 
 spec:
+  replicas: 0
   template:
     spec:
       affinity:
@@ -21,3 +22,11 @@ spec:
           operator: Equal
           value: "true"
           effect: NoSchedule
+      volumes:
+        - $patch: replace
+        - name: data
+          persistentVolumeClaim:
+            claimName: grafana-data
+        - name: config
+          configMap:
+            name: grafana

--- a/sakura-monitor/grafana/kustomization.yaml
+++ b/sakura-monitor/grafana/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
   - ../../monitor/grafana
+  - volume.yaml
+  - migrate-job.yaml
 
 patches:
   - path: ingress-route-patch.yaml

--- a/sakura-monitor/grafana/migrate-job.yaml
+++ b/sakura-monitor/grafana/migrate-job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grafana-data-migration
+  namespace: monitor
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      nodeName: sce311.tokyotech.org
+      tolerations:
+        - key: monitor-node
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: alpine:3.22
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              test -d /old-data
+              mkdir -p /new-data
+              cp -a /old-data/. /new-data/
+              sync
+          volumeMounts:
+            - name: old-data
+              mountPath: /old-data
+            - name: new-data
+              mountPath: /new-data
+      volumes:
+        - name: old-data
+          hostPath:
+            path: /srv/grafana/data
+            type: Directory
+        - name: new-data
+          persistentVolumeClaim:
+            claimName: grafana-data

--- a/sakura-monitor/grafana/volume.yaml
+++ b/sakura-monitor/grafana/volume.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+spec:
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce


### PR DESCRIPTION
#1452 の再適用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Grafana のデータストレージを永続化ボリュームとして構成しました
  * 既存データから新しいストレージへの自動移行プロセスを実装しました
  * Grafana デプロイメント構成を最適化しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->