### PR TITLE
nextcloudのmemory limitを上げる

### DIFF
--- a/nextcloud/deployment.yaml
+++ b/nextcloud/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           resources:
             limits:
               cpu: 1
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 200m
               memory: 128Mi
@@ -140,7 +140,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
             requests:
               cpu: 10m
               memory: 64Mi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チores（その他）**
  * Nextcloud サービスのメモリ割り当てを拡張しました。メイン コンテナは 256Mi から 1Gi に、バックグラウンド ジョブ コンテナは 128Mi から 256Mi にそれぞれ増加させました。これにより、システムの安定性とパフォーマンスが向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/manifest/pull/1657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->