### PR TITLE
Mig/preview for sakura

### DIFF
--- a/applications/application-set.yaml
+++ b/applications/application-set.yaml
@@ -41,6 +41,8 @@ spec:
             exclude: true
           - path: "portfolio-dev"
             exclude: true
+          - path: "preview-portfolio"
+            exclude: true
           - path: "room-vpn"
             exclude: true
           - path: "rucq"
@@ -94,6 +96,8 @@ spec:
           - path: "traq-dev"
             exclude: true
           - path: "traq"
+            exclude: true
+          - path: "preview-traq"
             exclude: true
           - path: "gitea"
             exclude: true

--- a/preview-portfolio-ui/values.yaml
+++ b/preview-portfolio-ui/values.yaml
@@ -19,8 +19,12 @@ preview:
 backend:
   matcher: PathPrefix(`/api`)
   service:
-    kind: TraefikService
-    name: "portfolio-ui-{{ . }}@file"
+    kind: Service
+    namespace: 'portfolio{{ if eq . "dev" }}-dev{{ end }}'
+    name: portfolio-backend
+    port: 8000
+    scheme: http
+    weight: 1
 
 staging:
   enabled: true

--- a/preview-portfolio-ui/values.yaml
+++ b/preview-portfolio-ui/values.yaml
@@ -22,7 +22,7 @@ backend:
     kind: Service
     namespace: 'portfolio{{ if eq . "dev" }}-dev{{ end }}'
     name: portfolio-backend
-    port: 8000
+    port: 3009
     scheme: http
     weight: 1
 

--- a/sakura-applications/application-set.yaml
+++ b/sakura-applications/application-set.yaml
@@ -45,6 +45,7 @@ spec:
           # portfolio
           - path: "portfolio"
           - path: "portfolio-dev"
+          - path: "preview-portfolio"
 
           # rucQ
           - path: "rucq"
@@ -102,6 +103,7 @@ spec:
           # traq
           - path: "traq-dev"
           - path: "traq"
+          - path: "preview-traq"
 
           # Gitea
           - path: "gitea"

--- a/traefik/config/static-file-provider.yaml
+++ b/traefik/config/static-file-provider.yaml
@@ -53,17 +53,6 @@ http:
 
     # preview-ui用の対応
     # k8sに移行したら、削除しSerivce直接指定にする
-    portfolio-ui-prod:
-      loadBalancer:
-        passHostHeader: false
-        servers:
-          - url: https://portfolio.trap.jp
-    portfolio-ui-dev:
-      loadBalancer:
-        passHostHeader: false
-        servers:
-          - url: https://portfolio-dev.trapti.tech
-
     knoq-prod:
       loadBalancer:
         passHostHeader: false


### PR DESCRIPTION
traQとportfolioのpreviewをさくらに移行
portfolioのserviceをTraefikServiceからServiceに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **Chores**
  * プレビュー対象のアプリ生成設定を更新し、一部プレビュー環境の追加／除外を整理しました。
  * ポートフォリオプレビューのバックエンド接続設定を Kubernetes Service 形式（namespace: portfolio/portfolio-dev 相当、port: 3009、scheme: http、weight: 1）へ切替えました。
  * 静的ルーティング定義からポートフォリオUI向けの直接的なロードバランサ定義を削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->