### PR TITLE
feat: set resource requests/limits on apps missing them

### DIFF
--- a/anke-to-dev/client-deployment.yaml
+++ b/anke-to-dev/client-deployment.yaml
@@ -23,3 +23,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/anke-to-dev/server-deployment.yaml
+++ b/anke-to-dev/server-deployment.yaml
@@ -41,3 +41,10 @@ spec:
           ports:
             - name: http
               containerPort: 3000
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/anke-to/client-deployment.yaml
+++ b/anke-to/client-deployment.yaml
@@ -31,3 +31,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"

--- a/anke-to/server-deployment.yaml
+++ b/anke-to/server-deployment.yaml
@@ -49,3 +49,10 @@ spec:
           ports:
             - name: http
               containerPort: 3000
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "48Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"

--- a/auth/template/templates/deployment.yaml
+++ b/auth/template/templates/deployment.yaml
@@ -36,6 +36,13 @@ spec:
           ports:
             - containerPort: 4181
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/booq/backend/deployment.yaml
+++ b/booq/backend/deployment.yaml
@@ -37,3 +37,10 @@ spec:
                 name: booq-secrets
           ports:
             - containerPort: 3001
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"

--- a/booq/frontend/deployment.yaml
+++ b/booq/frontend/deployment.yaml
@@ -21,3 +21,10 @@ spec:
           image: ghcr.io/traptitech/booq-ui:2.1.3
           ports:
             - containerPort: 80
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/codimd-dev/deployment-patch.yaml
+++ b/codimd-dev/deployment-patch.yaml
@@ -37,6 +37,13 @@ spec:
           ports:
             - containerPort: 3000
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "96Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           env:
             - name: CMD_DB_URL
               valueFrom:

--- a/codimd/deployment.yaml
+++ b/codimd/deployment.yaml
@@ -37,6 +37,13 @@ spec:
           ports:
             - containerPort: 3000
               name: http
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1536Mi"
           env:
             - name: CMD_DB_URL
               valueFrom:

--- a/emoine/deployment.yaml
+++ b/emoine/deployment.yaml
@@ -36,3 +36,10 @@ spec:
           envFrom:
             - secretRef:
                 name: emoine-secret
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/jomon-dev/backend-deployment.yaml
+++ b/jomon-dev/backend-deployment.yaml
@@ -29,6 +29,13 @@ spec:
           ports:
             - containerPort: 1323
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           env:
             - name: PORT
               value: "1323"

--- a/jomon-dev/frontend-deployment.yaml
+++ b/jomon-dev/frontend-deployment.yaml
@@ -20,3 +20,10 @@ spec:
           ports:
             - containerPort: 80
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/jomon/deployment.yaml
+++ b/jomon/deployment.yaml
@@ -31,6 +31,13 @@ spec:
           ports:
             - containerPort: 1323
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           env:
             - name: PORT
               value: "1323"

--- a/knoq-dev/backend-deployment-patch.yaml
+++ b/knoq-dev/backend-deployment-patch.yaml
@@ -19,6 +19,13 @@ spec:
       containers:
         - name: knoq-backend
           image: ghcr.io/traptitech/knoq:main@sha256:33ad7c0f3d9ceab6a723eea7ed297163c839bffdc363a0548dc6ffb941ad9422
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
           env:
             - name: MARIADB_USERNAME
               valueFrom:

--- a/knoq-dev/frontend-deployment-patch.yaml
+++ b/knoq-dev/frontend-deployment-patch.yaml
@@ -19,3 +19,10 @@ spec:
       containers:
         - name: knoq-frontend
           image: ghcr.io/traptitech/knoq-ui-v1:master@sha256:b50fd17e208a2160e7ed579462646337c089a8dc240e9638bc16758bf2cc8a6c
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"

--- a/knoq/backend-deployment.yaml
+++ b/knoq/backend-deployment.yaml
@@ -31,6 +31,13 @@ spec:
           ports:
             - containerPort: 3000
               name: http
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "96Mi"
+            limits:
+              cpu: "300m"
+              memory: "512Mi"
           env:
             - name: MARIADB_USERNAME
               valueFrom:

--- a/knoq/frontend-deployment.yaml
+++ b/knoq/frontend-deployment.yaml
@@ -31,3 +31,10 @@ spec:
           ports:
             - containerPort: 80
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"

--- a/litellm/deployment.yaml
+++ b/litellm/deployment.yaml
@@ -28,6 +28,13 @@ spec:
           image: ghcr.io/berriai/litellm:v1.82.3-stable.patch.2
           ports:
             - containerPort: 4000
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "768Mi"
+            limits:
+              cpu: "200m"
+              memory: "1Gi"
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml

--- a/minio-dev/deployment.yaml
+++ b/minio-dev/deployment.yaml
@@ -26,6 +26,13 @@ spec:
           ports:
             - containerPort: 9000
             - containerPort: 9001
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "320Mi"
+            limits:
+              cpu: "200m"
+              memory: "512Mi"
           volumeMounts:
             - name: storage
               mountPath: "/storage"

--- a/ns-dev-system/values.yaml
+++ b/ns-dev-system/values.yaml
@@ -214,6 +214,13 @@ sablier:
   enabled: true
   nodeSelector:
     kubernetes.io/hostname: eee101.tokyotech.org
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 
 ssgen:
   replicas: 2

--- a/ns-system/components/sablier-deployment.yaml
+++ b/ns-system/components/sablier-deployment.yaml
@@ -26,6 +26,13 @@ spec:
           ports:
             - name: http
               containerPort: 10000
+          resources:
+            requests:
+              cpu: "20m"
+              memory: "64Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
           volumeMounts:
             - name: config
               mountPath: /etc/sablier/sablier.yaml

--- a/portal-dev/backend/deployment.yaml
+++ b/portal-dev/backend/deployment.yaml
@@ -40,6 +40,13 @@ spec:
           ports:
             - containerPort: 3000
               protocol: TCP
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           volumeMounts:
             - mountPath: /app/ec_pub.pem
               name: ec-pub

--- a/portal-dev/frontend/deployment.yaml
+++ b/portal-dev/frontend/deployment.yaml
@@ -22,4 +22,11 @@ spec:
           ports:
             - containerPort: 80
               protocol: TCP
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
       restartPolicy: Always

--- a/portal-v2-dev/backend/deployment.yaml
+++ b/portal-v2-dev/backend/deployment.yaml
@@ -40,6 +40,13 @@ spec:
           ports:
             - containerPort: 3000
               protocol: TCP
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           volumeMounts:
             - mountPath: /app/ec_pub.pem
               name: ec-pub

--- a/portal/backend/deployment.yaml
+++ b/portal/backend/deployment.yaml
@@ -54,6 +54,13 @@ spec:
           ports:
             - containerPort: 3000
               protocol: TCP
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           volumeMounts:
             - mountPath: /app/ec_pub.pem
               name: ec-pub

--- a/portal/frontend/deployment.yaml
+++ b/portal/frontend/deployment.yaml
@@ -30,4 +30,11 @@ spec:
           ports:
             - containerPort: 80
               protocol: TCP
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
       restartPolicy: Always

--- a/portal/pipeline/deployment.yaml
+++ b/portal/pipeline/deployment.yaml
@@ -26,6 +26,13 @@ spec:
           image: ghcr.io/traptitech/pipeline:latest@sha256:8f29397f129441796ab86efb7ae98be6f9640fca381e3add47629aa5a33625cc
           ports:
             - containerPort: 8080
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           env:
             - name: PIPELINE_PRIKEY
               value: /keys/pri.key

--- a/portfolio-dev/backend/deployment.yaml
+++ b/portfolio-dev/backend/deployment.yaml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/traptitech/traportfolio:main@sha256:746ec9485d69fcd11e09a842dd62f18d16e191524d64cfea41e95e12b766566e
         ports:
         - containerPort: 1323
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "16Mi"
+          limits:
+            cpu: "100m"
+            memory: "64Mi"
         env:
         - name: TPF_PRODUCTION
           value: "true"

--- a/portfolio-dev/dashboard/deployment.yaml
+++ b/portfolio-dev/dashboard/deployment.yaml
@@ -22,4 +22,11 @@ spec:
           ports:
             - containerPort: 80
               protocol: TCP
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
       restartPolicy: Always

--- a/portfolio-dev/frontend/deployment.yaml
+++ b/portfolio-dev/frontend/deployment.yaml
@@ -22,4 +22,11 @@ spec:
           ports:
             - containerPort: 80
               protocol: TCP
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
       restartPolicy: Always

--- a/portfolio/backend/deployment.yaml
+++ b/portfolio/backend/deployment.yaml
@@ -21,6 +21,13 @@ spec:
           ports:
             - name: http
               containerPort: 1323
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"
           env:
             - name: TPF_PRODUCTION
               value: "true"

--- a/portfolio/dashboard/deployment.yaml
+++ b/portfolio/dashboard/deployment.yaml
@@ -22,3 +22,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"

--- a/portfolio/frontend/deployment.yaml
+++ b/portfolio/frontend/deployment.yaml
@@ -22,3 +22,10 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"

--- a/sablier/deployment.yaml
+++ b/sablier/deployment.yaml
@@ -26,6 +26,13 @@ spec:
           ports:
             - name: http
               containerPort: 10000
+          resources:
+            requests:
+              cpu: "20m"
+              memory: "48Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
           volumeMounts:
             - name: config
               mountPath: /etc/sablier/sablier.yaml

--- a/sakura-dev-ops-bot/deployment-patch.yaml
+++ b/sakura-dev-ops-bot/deployment-patch.yaml
@@ -17,6 +17,13 @@ spec:
           image: ghcr.io/traptitech/dev-ops-bot:5.0.1
           command:
             - /entrypoint.sh
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           env:
             - name: TRAQ_TOKEN
               valueFrom:

--- a/trap-collection/backend-deployment.yaml
+++ b/trap-collection/backend-deployment.yaml
@@ -31,6 +31,13 @@ spec:
           ports:
             - containerPort: 3001
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           env:
             - name: CLIENT_ID
               valueFrom:

--- a/trap-collection/frontend-deployment.yaml
+++ b/trap-collection/frontend-deployment.yaml
@@ -31,3 +31,10 @@ spec:
           ports:
             - containerPort: 80
               name: http
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "100m"
+              memory: "64Mi"

--- a/traq-dev/backend/deployment-patch.yaml
+++ b/traq-dev/backend/deployment-patch.yaml
@@ -10,6 +10,13 @@ spec:
       containers:
         - name: traq-backend
           image: ghcr.io/traptitech/traq:master@sha256:199151bc80f5e2b223f05e08798db9f2173049c2d09503c7181a7afe44e3d611
+          resources:
+            requests:
+              cpu: "20m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           env:
             - name: TRAQ_EXTERNALAUTH_TRAQ_CLIENTID
               valueFrom:

--- a/traq-dev/frontend/deployment-patch.yaml
+++ b/traq-dev/frontend/deployment-patch.yaml
@@ -10,6 +10,13 @@ spec:
       containers:
         - name: traq-frontend
           image: ghcr.io/traptitech/traq-ui:master@sha256:69f4d813a45ceebef6af570156321db58165d02d7068b35acf526744f55a9fd1
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "32Mi"
+            limits:
+              cpu: "40m"
+              memory: "128Mi"
           env:
             - name: NEW_RELIC_LICENSE_KEY
               value: "NRJS-5c70f08b45082feb140"

--- a/traq-dev/widget/deployment-patch.yaml
+++ b/traq-dev/widget/deployment-patch.yaml
@@ -7,3 +7,12 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/hostname: eee101.tokyotech.org
+      containers:
+        - name: traq-widget
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "16Mi"
+            limits:
+              cpu: "20m"
+              memory: "64Mi"


### PR DESCRIPTION
Add CPU/memory requests and limits to 26 apps (40 files) that previously had none, to stabilize the cluster without over-reserving node resources. Values are based on actual usage measured via Prometheus (memory: 14d max/avg, CPU: 7d peak/p95). Requests use ~average memory (startup spikes rely on swap), limits use ~1.5-2x measured peak. CPU requests kept low since all apps are near-idle on CPU.

Excludes infra-critical stacks (ArgoCD, Argo Workflows, Traefik, Grafana stack, Longhorn, cert-manager, system-upgrade-controller) and ConoHa-only apps not visible to the sakura Prometheus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * リソース管理の改善のため、複数のサービスに CPU とメモリのリソース要求と上限値を設定しました。これにより、システムの安定性と効率が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->