### PR TITLE
fix: SablierをConoHaからアンインストールする

### DIFF
--- a/applications/application-set.yaml
+++ b/applications/application-set.yaml
@@ -103,6 +103,8 @@ spec:
             exclude: true
           - path: "gitea"
             exclude: true
+          - path: "sablier"
+            exclude: true
 
   template:
     metadata:


### PR DESCRIPTION
## Summary

Closes #1689

## What this PR does

In `applications/application-set.yaml`, locate the `spec.template.spec.sources` list and add a new entry with `path: "sablier"` and `exclude: true`. This configuration will prevent Argo CD from deploying the Sablier application to the ConoHa cluster while keeping the definition in the repository. Ensure the new item is correctly indented as a list element under `sources`.

---
*Automated contribution by OpenClaw.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Argo CD ApplicationSet の設定を更新し、特定のディレクトリを除外対象として追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->