### PR TITLE
fix(sakura-monitor): grafana の resource limits を引き上げて OOMKill を解消

### DIFF
--- a/sakura-monitor/grafana/deployment-patch.yaml
+++ b/sakura-monitor/grafana/deployment-patch.yaml
@@ -30,11 +30,6 @@ spec:
                 secretKeyRef:
                   name: grafana-secrets
                   key: db-password
-          # base (monitor/grafana) の limits は memory 500Mi / cpu 300m。
-          # sce312 では定常 200-300Mi・周期的に ~500Mi までスパイクし、
-          # 500Mi の limit に張り付いて OOMKill による再起動を繰り返していた。
-          # limit に余裕を持たせて OOMKill を解消する。request は定常値ベースで控えめにし、
-          # 起動時スパイクはノードの Swap に委ねる。
           resources:
             requests:
               cpu: "100m"

--- a/sakura-monitor/grafana/deployment-patch.yaml
+++ b/sakura-monitor/grafana/deployment-patch.yaml
@@ -30,6 +30,18 @@ spec:
                 secretKeyRef:
                   name: grafana-secrets
                   key: db-password
+          # base (monitor/grafana) の limits は memory 500Mi / cpu 300m。
+          # sce312 では定常 200-300Mi・周期的に ~500Mi までスパイクし、
+          # 500Mi の limit に張り付いて OOMKill による再起動を繰り返していた。
+          # limit に余裕を持たせて OOMKill を解消する。request は定常値ベースで控えめにし、
+          # 起動時スパイクはノードの Swap に委ねる。
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "768Mi"
       volumes:
         - $patch: replace
         - name: data


### PR DESCRIPTION
## 概要

sce312 上の Grafana が「重い」問題の修正。grafana-trap (Prometheus) で実使用量を確認したところ、**memory limit 500Mi に張り付いて OOMKill による再起動を 17 回繰り返していた**ことが原因と判明したため、limit に余裕を持たせる。

## 診断結果（grafana-trap で確認）

| 指標 | 値 |
|---|---|
| Grafana メモリ使用（24h） | 定常 200〜310Mi、周期的に 469〜483Mi までスパイク |
| `max_over_time[7d]` | 499.7Mi（= 500Mi limit に到達） |
| コンテナ再起動回数 | **17回**（OOMKill の典型兆候） |
| CPU スロットリング | 約3〜4.5%（軽微・主因ではない） |

base の `monitor/grafana` に `limits: memory 500Mi / cpu 300m` があり、sakura-monitor の patch で上書きしていなかったため、窮屈な limit がそのまま効いていた。

**sce312 ノード残量**: allocatable CPU 4 / Memory 3815Mi、現状 request 合計 1.39core / 1410Mi（同居は victoria-metrics・tempo のみ）。request 枠に余裕あり。

## 変更内容

`sakura-monitor/grafana/deployment-patch.yaml` に `resources` を追加:

| | 変更前 (base) | 変更後 |
|---|---|---|
| requests.cpu | 10m | 100m |
| requests.memory | 50Mi | 256Mi |
| limits.cpu | 300m | 500m |
| limits.memory | **500Mi** | **768Mi** |

- memory limit を観測ピーク約500Miに対し約53%の余裕を持たせて OOMKill を解消
- request は定常値ベースで控えめに設定（過剰 request を回避）
- 起動時スパイクはノードの Swap に委ねる方針
- メモリ逼迫ノードに配慮し、過剰な 1Gi ではなく 768Mi に抑制

## 検証

- `kustomize build`（ksops dry-run スタブ使用）: 成功、resources が意図通りレンダリング
- `kubeconform`: 7リソース全て Valid
- `prettier --check`: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Grafana の実行リソース（CPU/メモリ）設定を追加し、メモリ不足による再起動を起きにくくしました。
  * 負荷が高い状況でも、監視画面がより安定して表示されやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->