### PR TITLE
grafana-mcpのtransportをsseからstreamable-httpにした

### DIFF
--- a/monitor/grafana-mcp/deployment.yaml
+++ b/monitor/grafana-mcp/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --transport
-            - sse
+            - streamable-http
             - --disable-write
           ports:
             - name: http


### PR DESCRIPTION
SSEはCodex非対応、Claude Codeでも非推奨のため