### PR TITLE
ns-mariadb: max_connectionsを増やす

### DIFF
--- a/ns-system/db/config/90-tuning.cnf
+++ b/ns-system/db/config/90-tuning.cnf
@@ -7,3 +7,4 @@
 # Most important is to give InnoDB 80 % of the system RAM for buffer use:
 # https://mariadb.com/kb/en/innodb-system-variables/#innodb_buffer_pool_size
 innodb_buffer_pool_size = 64Mi
+max_connections = 500

--- a/ns-system/db/kustomization.yaml
+++ b/ns-system/db/kustomization.yaml
@@ -14,5 +14,5 @@ resources:
 configMapGenerator:
   - name: mariadb-config
     files:
-      - config/90-limit-buffer.cnf
+      - config/90-tuning.cnf
       - config/80-slow-query.cnf

--- a/ns-system/db/mariadb-stateful-set.yaml
+++ b/ns-system/db/mariadb-stateful-set.yaml
@@ -43,9 +43,9 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: data
-            - mountPath: /etc/mysql/mariadb.conf.d/90-limit-buffer.cnf
+            - mountPath: /etc/mysql/mariadb.conf.d/90-tuning.cnf
               name: config
-              subPath: 90-limit-buffer.cnf
+              subPath: 90-tuning.cnf
             - mountPath: /etc/mysql/mariadb.conf.d/80-slow-query.cnf
               name: config
               subPath: 80-slow-query.cnf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * MariaDB の同時接続数上限を 500 に引き上げ、より多くの接続を安定して処理できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->