### PR TITLE
さくらのns-builderを止める

### DIFF
--- a/ns-system/components/builder-deployment.yaml
+++ b/ns-system/components/builder-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ns-builder
 
 spec:
-  replicas: 1
+  replicas: 0
   revisionHistoryLimit: 0
   selector:
     matchLabels:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Builder 用のデプロイ設定を更新し、対象 Pod の起動数が 0 になるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->