### PR TITLE
ns-dev-apps: add network policy

### DIFF
--- a/ns-dev-apps/kustomization.yaml
+++ b/ns-dev-apps/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - ../ns-apps
+  - network-policy.yaml

--- a/ns-dev-apps/network-policy.yaml
+++ b/ns-dev-apps/network-policy.yaml
@@ -18,6 +18,14 @@ spec:
               - 172.16.0.0/12
               - 192.168.0.0/16
     - to:
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - fc00::/7
+              - fe80::/10
+              - 2001:cafe:42:0::/56 # Pod CIDR
+              - 2001:cafe:42:1::/112 # Service CIDR
+    - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system

--- a/ns-dev-apps/network-policy.yaml
+++ b/ns-dev-apps/network-policy.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: apps-network-policy
+
+spec:
+  podSelector:
+    matchLabels:
+      ns.trap.jp/managed: "true"
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ns-dev-system
+          podSelector:
+            matchLabels:
+              app: mariadb
+      ports:
+        - protocol: TCP
+          port: mariadb
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ns-dev-system
+          podSelector:
+            matchLabels:
+              app: mongo
+      ports:
+        - protocol: TCP
+          port: mongo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 管理対象 Pod の外向き通信を制御する NetworkPolicy を追加しました。
  * 一般通信は必要な宛先に限定し、ローカル/一部の IPv6 範囲は除外しました。
  * DNS（kube-dns）への到達を許可し、ns-dev-system 内の MariaDB／Mongo 宛ては対象ポートのみ許可しました。
* **変更**
  * デプロイに新しいネットワーク制御設定を含めるよう更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->