### PR TITLE
fix(ns-dev-apps): traefikへの通信を許可

### DIFF
--- a/ns-dev-apps/network-policy.yaml
+++ b/ns-dev-apps/network-policy.yaml
@@ -52,3 +52,10 @@ spec:
       ports:
         - protocol: TCP
           port: mongo
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+            podSelector:
+              matchLabels:
+                app.kubernetes.io/name: traefik


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * アプリのネットワーク通信制御を更新し、Traefik への接続が許可されるようになりました。
  * これにより、関連する通信エラーやアクセス不具合が改善される場合があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->