### PR TITLE
chore: sakura-monitor以下のアプリをsce312に変更

### DIFF
--- a/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
+++ b/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
@@ -7,7 +7,7 @@ spec:
   templates:
     - name: run
       nodeSelector:
-        kubernetes.io/hostname: sce311.tokyotech.org
+        kubernetes.io/hostname: sce312.tokyotech.org
 
       # 消してもpatch元のvolumes, containerが反映されなかったため、残しておく
       volumes:

--- a/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
+++ b/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
@@ -19,8 +19,8 @@ spec:
           secret:
             secretName: backup-keys
         - name: data
-          hostPath:
-            path: /srv/grafana/data
+          persistentVolumeClaim:
+            claimName: grafana-data
 
       container:
         name: backup

--- a/sakura-monitor/blackbox-exporter/deployment-patch.yaml
+++ b/sakura-monitor/blackbox-exporter/deployment-patch.yaml
@@ -15,7 +15,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - sce311.tokyotech.org
+                      - sce312.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/sakura-monitor/domain-exporter/deployment-patch.yaml
+++ b/sakura-monitor/domain-exporter/deployment-patch.yaml
@@ -14,7 +14,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - sce311.tokyotech.org
+                      - sce312.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/sakura-monitor/kube-state-metrics/deployment-patch.yaml
+++ b/sakura-monitor/kube-state-metrics/deployment-patch.yaml
@@ -14,7 +14,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - sce311.tokyotech.org
+                      - sce312.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/sakura-monitor/loki/stateful-set-patch.yaml
+++ b/sakura-monitor/loki/stateful-set-patch.yaml
@@ -15,7 +15,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - sce311.tokyotech.org
+                      - sce312.tokyotech.org
       tolerations:
         - key: monitor-node
           operator: Equal

--- a/sakura-monitor/loki/stateful-set-patch.yaml
+++ b/sakura-monitor/loki/stateful-set-patch.yaml
@@ -28,7 +28,7 @@ spec:
             - name: http-metrics
               containerPort: 3100
               protocol: TCP
-              hostIP: 192.168.1.19
+              hostIP: 192.168.1.20
               hostPort: 9300
 
           volumeMounts:

--- a/sakura-monitor/s3-exporter/deployment-patch.yaml
+++ b/sakura-monitor/s3-exporter/deployment-patch.yaml
@@ -14,7 +14,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - sce311.tokyotech.org
+                      - sce312.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/sakura-monitor/ssl-exporter/deployment-patch.yaml
+++ b/sakura-monitor/ssl-exporter/deployment-patch.yaml
@@ -14,7 +14,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - sce311.tokyotech.org
+                      - sce312.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/sakura-monitor/victoria-metrics/config/prometheus.yml
+++ b/sakura-monitor/victoria-metrics/config/prometheus.yml
@@ -585,7 +585,7 @@ scrape_configs:
           - ict202.tokyotech.org
           - ict203.tokyotech.org
           - private.csc301.tokyotech.org
-          - private.sce311.tokyotech.org
+          - private.sce312.tokyotech.org
           - private.iee221.tokyotech.org
           - eee101.tokyotech.org
           - arc321.tokyotech.org

--- a/sakura-monitor/victoria-metrics/config/prometheus.yml
+++ b/sakura-monitor/victoria-metrics/config/prometheus.yml
@@ -585,6 +585,7 @@ scrape_configs:
           - ict202.tokyotech.org
           - ict203.tokyotech.org
           - private.csc301.tokyotech.org
+          - private.sce311.tokyotech.org
           - private.sce312.tokyotech.org
           - private.iee221.tokyotech.org
           - eee101.tokyotech.org


### PR DESCRIPTION
close #1588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * Grafanaバックアップの実行ノードを更新し、バックアップ参照先をノードローカルのボリュームからPVC（grafana-data）へ切り替えました。  
  * Blackbox Exporter / Domain Exporter / kube-state-metrics / Loki / S3 Exporter / SSL Exporter の配置先を新しい監視ノードへ更新しました（Lokiの参照IPも変更）。  
  * ICMP監視の対象ホスト（blackbox_icmp）を新しいホストへ切り替えました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->