### PR TITLE
restore: portal.trapti.techにcertificateをつけます

### DIFF
--- a/portal/certificate.yaml
+++ b/portal/certificate.yaml
@@ -12,5 +12,6 @@ spec:
   renewBefore: 720h0m0s # 30d
   dnsNames:
     - portal.trap.jp
+    - portal.trapti.tech
     - portal.trap.show
     - portal.trap.games


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `portal.trapti.tech` を証明書の対象DNS名に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->