### PR TITLE
fix:harbor-credentials-encrypt

### DIFF
--- a/harbor/ksops.yaml
+++ b/harbor/ksops.yaml
@@ -12,3 +12,5 @@ files:
   - ./secrets/admin-password.enc.yaml
   - ./secrets/secret-key.enc.yaml
   - ./secrets/storage.enc.yaml
+  - ./secrets/registry-credentials.enc.yaml
+  - ./secrets/database-credentials.enc.yaml

--- a/harbor/secrets/database-credentials.enc.yaml
+++ b/harbor/secrets/database-credentials.enc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: database-credentials
+    annotations:
+        kustomize.config.k8s.io/needs-hash: "true"
+    namespace: harbor
+stringData:
+    password: ENC[AES256_GCM,data:1n12B5W6JXo=,iv:6+HJUeeBuxD4iJhDz2tSBPYqmNb7P4JqaWcdJ5PY02w=,tag:ZgQm9YsczkhuL7FGtNTy7w==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxYW9ZSGljT1NMZER6YVZB
+            S1kxcS85cVJ0by9DdlFUM2dBSEorYThZNkNvCkp6UE5NZ0dtdVYxMTQvckVGK2da
+            bVBzeWU0OGxzVTZVdmgxS2JMZ2w1UGcKLS0tIDc3MGZDa2N3bkp2a2RDdnBwWUFl
+            eFRMTXMzUVNVUjdLQnNhY01Hc1hIV0UK54GZ06E4dNkk35IbesRCUys7jmGoML5j
+            esBqi590UP2VUvJ2I0VSZgXTjFJafVX0W/xYt/+YHlUV552FLiIubw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+    lastmodified: "2026-07-15T02:48:08Z"
+    mac: ENC[AES256_GCM,data:WusQMt83/d1QAytI5CWexeUdJCleUbgeTFpN8p4UrrNxBy9S9+BwKdG2N89CCdPDfB3iXcBIN5YIpI+Zm7C5EJJhhB0DPxibG+9c/fLf/N9mxNzUZa/ZaGCKtYw7Mmk0zZjIqzgdL4MSe+DynNRNsmcdB+4AGYlSiJWdp04PstM=,iv:hylRtbF1NmnXvE1DYsOShqBKbrhxBhSPAegyCdqAQvE=,tag:HuZ+NqFmaveuHRpg+I6L7g==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.13.1

--- a/harbor/secrets/registry-credentials.enc.yaml
+++ b/harbor/secrets/registry-credentials.enc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: registry-credentials
+    annotations:
+        kustomize.config.k8s.io/needs-hash: "true"
+    namespace: harbor
+stringData:
+    REGISTRY_PASSWD: ENC[AES256_GCM,data:gEMK/o0qaMg=,iv:5bJ54yaDU1k/aMQZ9Oi6JAxoVd2SsL5Dvp6oAW8Zn8Y=,tag:XnFE5gr4SXiwwDpjc+CI1w==,type:str]
+    REGISTRY_HTPASSWD: ENC[AES256_GCM,data:1WYjYimIaJd2grtp6yWLDcDM7IOZaA9CiMYbpoGkx+cEFbuXq0o0I4cqB7W2d7dMAJqpEsVxGQInBMGbey806lxW5vVi,iv:8EZI83B8VCNnnRbWYzv5mZng2ivn6orn6NKrkSvivnw=,tag:pVVJ3D270fJOcDataKlmeA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrK3h6UWYwWFhtYXJpanpW
+            SU1qZ1NPUUtuVjlCd0RxVWVvWU1tMFpyWkdRCkQrdVNHQ2FLaXl4R1hCSjEzRW4r
+            Qy9nWnc1YVlESldlcDh3d1M2c0FIV1kKLS0tIGNiVE1KaDdSRWRHYmRkQ3VDaFpM
+            bXdacUFSMHptVXpkV0N0dXMvTmxJRDQKbjpCDIDZ3FwnW+Mn6I4Ij1vh8gRSNzYr
+            mqv+tYWV+f/DrsHVkAFZ5AzYXVdqVHHPNGkBZE9jf9YGVGgoGEMUhQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age156red4ptw5huzpwlfnrukg4htuucdweu9jg8usjz98ggmeyedces3xqplq
+    lastmodified: "2026-07-15T02:48:08Z"
+    mac: ENC[AES256_GCM,data:eZ6Ly8xD+HAxJA42BExLsemXhQjew+5Z/LoBUbh9T2DMjxH5vbfTU2vSbN8GVcSf9r+yi8PGQ/8swnr+cwEm5GstnFxUCFblggRJJ5GF7vXfL/nTDfv4riqjXRrfggKyntTejtSowWERCaPCz2EYXN2K7GwBy2Dy82PyDGUvx5A=,iv:2zxKM2XC9BJLMpSaWh+E0+bMPLGdqZ6JIAIFY/qlsDA=,tag:8EvpnxSky0FDW095YEXXvw==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.13.1

--- a/harbor/values.yaml
+++ b/harbor/values.yaml
@@ -64,6 +64,12 @@ core:
   # core-cert generated with the following helm function: genCA "harbor-token-ca" 36500
   secretName: core-cert
   revisionHistoryLimit: 0
+  extraEnvVars:
+    - name: POSTGRESQL_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: database-credentials
+          key: password
   resources:
     requests:
       cpu: "100m"
@@ -114,10 +120,7 @@ registry:
   revisionHistoryLimit: 0
   credentials:
     username: "registry"
-    password: "password"
-    # Login and password in htpasswd string format. Excludes `registry.credentials.username`  and `registry.credentials.password`. May come in handy when integrating with tools like argocd or flux. This allows the same line to be generated each time the template is rendered, instead of the `htpasswd` function from helm, which generates different lines each time because of the salt.
-    # NOTE: has to match with above username/password, see: https://github.com/goharbor/harbor-helm/issues/1210
-    htpasswdString: "registry:$2a$10$hktXbwlqdEiTyxGbBDGFtO./2Zk.FQF5Dr9klO1hL7RUsZyq1O3ay"
+    existingSecret: registry-credentials
 
 trivy:
   enabled: false
@@ -135,7 +138,14 @@ trivy:
 database:
   type: internal
   internal:
-    password: "password"
+    # The actual password is provided from database-credentials.
+    password: "unused-managed-by-database-credentials"
+    extraEnvVars:
+      - name: POSTGRES_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: database-credentials
+            key: password
     shmSizeLimit: 128Mi
     livenessProbe:
       timeoutSeconds: 5
@@ -168,6 +178,12 @@ redis:
 
 exporter:
   revisionHistoryLimit: 0
+  extraEnvVars:
+    - name: HARBOR_DATABASE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: database-credentials
+          key: password
 
 metrics:
   enabled: false


### PR DESCRIPTION
harborの機微情報がvalues.yamlに直接書かれていたためこれをsecretsへ切り出した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - データベースおよびレジストリ認証情報を暗号化されたシークレットとして追加しました。
  - 各Harborコンポーネントが、平文の認証情報ではなく既存のシークレットを参照するようになりました。
  - シークレット更新時に関連リソースのハッシュが更新される設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->