### PR TITLE
Downgrade ns-ssgen caddy to 2.11.3

### DIFF
--- a/ns-system/components/ssgen-stateful-set.yaml
+++ b/ns-system/components/ssgen-stateful-set.yaml
@@ -107,7 +107,7 @@ spec:
               memory: "50Mi"
 
         - name: caddy
-          image: caddy:2-alpine
+          image: caddy:2.11.3-alpine
           imagePullPolicy: Always
           ports:
             - containerPort: 80


### PR DESCRIPTION
サブパス以下が配信されないバグを直すため (直ると良いな)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Caddyをバージョン2.11.3へ更新し、安定性とセキュリティの向上を図りました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->