### PR TITLE
Traefik Dashboardをルートでも見られるように

### DIFF
--- a/sakura-traefik/values.yaml
+++ b/sakura-traefik/values.yaml
@@ -154,7 +154,7 @@ ingressRoute:
     enabled: true
     entryPoints:
       - websecure
-    matchRule: Host(`s-traefik.trap.jp`) && (PathPrefix(`/dashboard`) || PathPrefix(`/api`))
+    matchRule: Host(`s-traefik.trap.jp`)
     middlewares:
       - name: auth-trap-jp-hard
         namespace: auth


### PR DESCRIPTION
Helm移行時に動作が変わっていた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Traefikダッシュボードへのアクセス条件を見直し、指定されたホスト名で正しくアクセスできるようになりました。
  * `/dashboard` や `/api` のパス条件に依存せず、ダッシュボード関連のリクエストが処理されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->