### PR TITLE
libraにあるPodをc1-203に移行・ストレージを持つPodを停止

### DIFF
--- a/dev-ops-bot/config/config.yaml
+++ b/dev-ops-bot/config/config.yaml
@@ -511,17 +511,6 @@ commands:
           - Takeno_hito
           - cp20
 
-      - name: libra
-        templateRef: server
-        allowArgs: true
-        argsSyntax: "[SOFT|HARD]"
-        argsPrefix:
-          - restart
-          - 88b9eeec-a94f-4c4c-a8fe-c0dc20b75657
-        operators:
-          - Takeno_hito
-          - cp20
-
       - name: w933
         templateRef: server
         allowArgs: true

--- a/monitor/backup/grafana-backup-workflow-template.yaml
+++ b/monitor/backup/grafana-backup-workflow-template.yaml
@@ -10,7 +10,7 @@ spec:
   templates:
     - name: run
       nodeSelector:
-        kubernetes.io/hostname: libra.tokyotech.org
+        kubernetes.io/hostname: c1-203.tokyotech.org
 
       volumes:
         - name: scripts

--- a/monitor/blackbox-exporter/deployment.yaml
+++ b/monitor/blackbox-exporter/deployment.yaml
@@ -36,7 +36,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/monitor/conoha-exporter/deployment.yaml
+++ b/monitor/conoha-exporter/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/monitor/domain-exporter/deployment.yaml
+++ b/monitor/domain-exporter/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/monitor/grafana/deployment.yaml
+++ b/monitor/grafana/deployment.yaml
@@ -28,7 +28,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/monitor/kube-state-metrics/deployment.yaml
+++ b/monitor/kube-state-metrics/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/monitor/kustomization.yaml
+++ b/monitor/kustomization.yaml
@@ -11,3 +11,11 @@ resources:
   - s3-exporter
   - ssl-exporter
   - victoria-metrics
+
+replicas:
+  - name: grafana
+    count: 0
+  - name: victoria-metrics
+    count: 0
+  - name: loki
+    count: 0

--- a/monitor/loki/stateful-set.yaml
+++ b/monitor/loki/stateful-set.yaml
@@ -45,7 +45,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
       tolerations:
         - key: monitor-node
           operator: Equal
@@ -78,7 +78,7 @@ spec:
               containerPort: 3100
               protocol: TCP
               # for compatibility with old infra; TODO: remove old host port expose
-              hostIP: 192.168.0.6
+              hostIP: 192.168.0.13
               hostPort: 9300
             - name: grpc
               containerPort: 9095

--- a/monitor/s3-exporter/deployment.yaml
+++ b/monitor/s3-exporter/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/monitor/ssl-exporter/deployment.yaml
+++ b/monitor/ssl-exporter/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/monitor/victoria-metrics/config/prometheus.yml
+++ b/monitor/victoria-metrics/config/prometheus.yml
@@ -561,7 +561,6 @@ scrape_configs:
     static_configs:
       - targets:
           - private.kmbk.tokyotech.org
-          - private.libra.tokyotech.org
           - private.m011.tokyotech.org
           - private.w933.tokyotech.org
           - private.c1-203.tokyotech.org

--- a/monitor/victoria-metrics/stateful-set.yaml
+++ b/monitor/victoria-metrics/stateful-set.yaml
@@ -38,7 +38,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - libra.tokyotech.org
+                      - c1-203.tokyotech.org
               weight: 1
       tolerations:
         - key: monitor-node

--- a/sakura-dev-ops-bot/config/config.yaml
+++ b/sakura-dev-ops-bot/config/config.yaml
@@ -582,17 +582,6 @@ commands:
           - Takeno_hito
           - cp20
 
-      - name: libra
-        templateRef: server
-        allowArgs: true
-        argsSyntax: "[SOFT|HARD]"
-        argsPrefix:
-          - restart
-          - 88b9eeec-a94f-4c4c-a8fe-c0dc20b75657
-        operators:
-          - Takeno_hito
-          - cp20
-
       - name: w933
         templateRef: server
         allowArgs: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * サーバー再起動コマンドの対象を更新し、`w933` および `c1-203` を指定できるようにしました。
  * 監視・バックアップ関連サービスの優先実行先を `c1-203` に切り替えました。
  * Grafana、VictoriaMetrics、Loki のレプリカ数を 0 に設定し、停止状態で管理できるようにしました。
  * ICMP監視対象から旧サーバーを除外しました。
  * Lokiのメトリクス通信先を新しいアドレスへ更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->