### PR TITLE
fix(victoria-metrics): ストレージのサイズ増やす

### DIFF
--- a/sakura-monitor/victoria-metrics/stateful-set-patch.yaml
+++ b/sakura-monitor/victoria-metrics/stateful-set-patch.yaml
@@ -16,7 +16,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 20Gi
   template:
     spec:
       affinity:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 永続ストレージの容量を10Giから20Giに増量し、より多くのデータを保存できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->