### PR TITLE
fix: anke-to用のprometheus configを削除

### DIFF
--- a/monitor/victoria-metrics/config/prometheus.yml
+++ b/monitor/victoria-metrics/config/prometheus.yml
@@ -416,22 +416,6 @@ scrape_configs:
         replacement: ${1}
 
   # TODO: replace with service annotation "prometheus.io/scrape: true" once service is running on the cluster
-  - job_name: anke-to
-    metrics_path: /metrics
-    scheme: https
-    static_configs:
-      - targets:
-          - anke-to-dev.trapti.tech:443
-          - anke-to.trap.jp:443
-    tls_config:
-      insecure_skip_verify: true
-    relabel_configs:
-      - source_labels: [__address__]
-        target_label: instance
-        regex: ([^:]+):.+
-        replacement: ${1}
-
-  # TODO: replace with service annotation "prometheus.io/scrape: true" once service is running on the cluster
   - job_name: trap-collection
     metrics_path: /api/metrics
     scheme: https

--- a/sakura-monitor/victoria-metrics/config/prometheus.yml
+++ b/sakura-monitor/victoria-metrics/config/prometheus.yml
@@ -438,22 +438,6 @@ scrape_configs:
         replacement: ${1}
 
   # TODO: replace with service annotation "prometheus.io/scrape: true" once service is running on the cluster
-  - job_name: anke-to
-    metrics_path: /metrics
-    scheme: https
-    static_configs:
-      - targets:
-          - anke-to-dev.trapti.tech:443
-          - anke-to.trap.jp:443
-    tls_config:
-      insecure_skip_verify: true
-    relabel_configs:
-      - source_labels: [__address__]
-        target_label: instance
-        regex: ([^:]+):.+
-        replacement: ${1}
-
-  # TODO: replace with service annotation "prometheus.io/scrape: true" once service is running on the cluster
   - job_name: trap-collection
     metrics_path: /api/metrics
     scheme: https


### PR DESCRIPTION
anke-toは`/metrics`を公開していないのにスクレイピングしようとして、victoria metricsにwarnログが出ている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **監視設定**
  * `anke-to` の監視ジョブを削除しました。
  * 同サービスの `/metrics` エンドポイントに対する HTTPS スクレイピングを停止しました。
  * その他の監視設定に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->