### PR TITLE
sce312に監視ノード用taintを追加

### DIFF
--- a/sakura-applications/nodes.yaml
+++ b/sakura-applications/nodes.yaml
@@ -68,3 +68,9 @@ metadata:
   name: sce312.tokyotech.org
   labels:
     node-role.kubernetes.io/ingress: "true"
+
+spec:
+  taints:
+    - key: monitor-node
+      value: "true"
+      effect: NoSchedule


### PR DESCRIPTION
## 変更内容

- `sce312.tokyotech.org` に `monitor-node=true:NoSchedule` の taint を追加
  - `sce311.tokyotech.org` と同じ監視ノード向けのスケジューリング制御を適用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * 特定のノードにスケジュール制約を追加し、対象ノードへのワークロード配置を制御できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->