### PR TITLE
ServiceLBのPodをingressノードに限定

### DIFF
--- a/sakura-applications/nodes.yaml
+++ b/sakura-applications/nodes.yaml
@@ -54,6 +54,7 @@ metadata:
   name: csc301.tokyotech.org
   labels:
     node-role.kubernetes.io/ingress: "true"
+    svccontroller.k3s.cattle.io/enablelb: "true"
 ---
 apiVersion: v1
 kind: Node
@@ -61,6 +62,7 @@ metadata:
   name: las211.tokyotech.org
   labels:
     node-role.kubernetes.io/ingress: "true"
+    svccontroller.k3s.cattle.io/enablelb: "true"
 ---
 apiVersion: v1
 kind: Node
@@ -68,3 +70,4 @@ metadata:
   name: sce312.tokyotech.org
   labels:
     node-role.kubernetes.io/ingress: "true"
+    svccontroller.k3s.cattle.io/enablelb: "true"

--- a/sakura-applications/nodes.yaml
+++ b/sakura-applications/nodes.yaml
@@ -70,4 +70,3 @@ metadata:
   name: sce312.tokyotech.org
   labels:
     node-role.kubernetes.io/ingress: "true"
-    svccontroller.k3s.cattle.io/enablelb: "true"


### PR DESCRIPTION
## 理由

NeoShowcase app が公開する各 LoadBalancer Service に対し、K3s ServiceLB の Pod がクラスタ内の多数のノードへ展開され、リソースを無駄に消費している。
具体的にはノードごとに31個のPodが無駄に配置されている。

Closes #1780

## 変更内容

- ingress 用の3ノードに `svccontroller.k3s.cattle.io/enablelb=true` ラベルを追加
  - K3s ServiceLB が許可リストモードになり、LoadBalancer Pod が ingress ノードだけに配置されるようになる

### 注意点

適用後、ingressノード以外のNodeではServiceのポートを受け付けなくなる。
恐らくアナウンスが必要。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * `csc301.tokyotech.org` と `las211.tokyotech.org` で、ロードバランサー機能が利用可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->