### PR TITLE
remove sce312 from ingress nodes

### DIFF
--- a/sakura-applications/nodes.yaml
+++ b/sakura-applications/nodes.yaml
@@ -61,10 +61,3 @@ metadata:
   name: las211.tokyotech.org
   labels:
     node-role.kubernetes.io/ingress: "true"
----
-apiVersion: v1
-kind: Node
-metadata:
-  name: sce312.tokyotech.org
-  labels:
-    node-role.kubernetes.io/ingress: "true"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **変更**
  * Kubernetes ノード「sce312.tokyotech.org」から、Ingress 用ラベルを削除しました。
  * ノード本体、監視用設定、その他の設定に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->