### PR TITLE
fix(sakura-monitor): GrafanaバックアップをMySQL対応

### DIFF
--- a/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
+++ b/sakura-monitor/backup/grafana-backup-workflow-template-patch.yaml
@@ -9,7 +9,6 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: sce312.tokyotech.org
 
-      # 消してもpatch元のvolumes, containerが反映されなかったため、残しておく
       volumes:
         - name: scripts
           configMap:
@@ -18,9 +17,6 @@ spec:
         - name: keys
           secret:
             secretName: backup-keys
-        - name: data
-          persistentVolumeClaim:
-            claimName: grafana-data
 
       container:
         name: backup
@@ -33,8 +29,20 @@ spec:
             name: scripts
           - mountPath: /keys
             name: keys
-          - mountPath: /data
-            name: data
+        env:
+          - name: DB_HOST
+            value: tailscale.kmbk.tokyotech.org
+          - name: DB_PORT
+            value: "3306"
+          - name: DB_NAME
+            value: service_grafana
+          - name: DB_USER
+            value: service_grafana
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: grafana-secrets
+                key: db-password
 
       tolerations:
         - key: monitor-node

--- a/sakura-monitor/backup/scripts/backup-grafana.sh
+++ b/sakura-monitor/backup/scripts/backup-grafana.sh
@@ -2,7 +2,18 @@
 
 set -euxo pipefail
 
-gzip < /data/grafana.db > /data/grafana-sakura.db.gz
+apk add --no-cache mariadb-client
+
+set +x
+mariadb-dump \
+  --host="$DB_HOST" \
+  --port="$DB_PORT" \
+  --user="$DB_USER" \
+  --password="$DB_PASSWORD" \
+  --single-transaction \
+  --default-character-set=utf8mb4 \
+  "$DB_NAME" | gzip > /tmp/grafana-sakura.db.gz
+set -x
 
 gcloud auth activate-service-account backup@trap-sysad.iam.gserviceaccount.com --key-file=/keys/key.json
-gsutil cp /data/grafana-sakura.db.gz gs://trap-services-backup/
+gsutil cp /tmp/grafana-sakura.db.gz gs://trap-services-backup/


### PR DESCRIPTION
## Why
 
さくらの Grafana は SQLite ではなく外部 MySQL を利用しているため、PVC 上の `/data/grafana.db` を圧縮する既存スクリプトがファイル未検出で失敗していた。

## What Changed

- バックアップスクリプトを `mariadb-dump` に切り替え、`service_grafana` データベースを gzip 圧縮して GCS へ保存するようにした

## Verification

`mise run build sakura-monitor/backup`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Grafanaのバックアップ方式を、ローカルデータの圧縮からMariaDBデータベースのダンプ取得に変更しました。
  * データベース接続情報を環境変数で指定できるようになりました。
  * 取得したバックアップは引き続きGCSへアップロードされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->