### PR TITLE
fix(renovate): Renovateのバージョンを固定

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -98,7 +98,8 @@ jobs:
         uses: renovatebot/github-action@39b914146caeff8cd512e61c8992f1d5913af85c # v46.2.5
         with:
           renovate-image: "ghcr.io/renovatebot/renovate"
-          renovate-version: "latest"
+          # renovate:general datasource=docker depName=renovatebot/renovate registryUrl=https://ghcr.io
+          renovate-version: "44.64.1"
           configurationFile: "${{ env.RENOVATE_CONFIG_FILE }}"
           token: "${{ steps.generate-token.outputs.token }}"
         env:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: renovatebot/github-action@39b914146caeff8cd512e61c8992f1d5913af85c # v46.2.5
         with:
           renovate-image: "ghcr.io/renovatebot/renovate"
-          # renovate:general datasource=docker depName=renovatebot/renovate registryUrl=https://ghcr.io
+          # renovate:general datasource=github-releases depName=renovatebot/renovate
           renovate-version: "44.64.1"
           configurationFile: "${{ env.RENOVATE_CONFIG_FILE }}"
           token: "${{ steps.generate-token.outputs.token }}"


### PR DESCRIPTION
## Why

Renovate 44.64.0 にて、 `tar` 欠落によりActionsが失敗する問題があった。

https://github.com/traPtitech/manifest/actions/runs/33884473621/job/101060789064#step:7:400

## What Changed

- `renovate-version` を上流で修正済みの `44.64.1` に固定
- Renovate の custom manager から GitHub Releases を追跡させ、リリース日時に基づいて設定済みの `minimumReleaseAge` を適用できるように変更
  - 対象ルール: https://github.com/traPtitech/manifest/blob/7b218428ab91c7142b6b9f059c03080c94045cd9/.github/renovate/regex-manager.json5#L9

## Verification

- [44.64.0 の実行](https://github.com/traPtitech/manifest/actions/runs/33875879056)で `Cannot find package 'tar' imported from /usr/local/renovate/dist/modules/datasource/apk/index.js` を再現
- [44.64.1 の実行](https://github.com/traPtitech/manifest/actions/runs/33901369184)で Renovate が正常完了することを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renovateの使用バージョンを44.64.1に固定しました。
  * GitHub Releasesを対象とする更新管理コメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->