### PR TITLE
fix(grafana): リソース制限をSakura環境に合わせる

### DIFF
--- a/monitor/grafana/deployment.yaml
+++ b/monitor/grafana/deployment.yaml
@@ -60,8 +60,8 @@ spec:
 
           resources:
             requests:
-              cpu: "10m"
-              memory: "50Mi"
+              cpu: "100m"
+              memory: "256Mi"
             limits:
-              cpu: "300m"
-              memory: "500Mi"
+              cpu: "500m"
+              memory: "768Mi"


### PR DESCRIPTION
## Why

Grafana がリソース不足で落ちる

## What Changed

- CPU request: `10m` → `100m`
- Memory request: `50Mi` → `256Mi`
- CPU limit: `300m` → `500m`
- Memory limit: `500Mi` → `768Mi`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * Grafana のCPU・メモリリソース要求量を増加しました。
  * Grafana のCPU・メモリ使用上限を引き上げました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->