### PR TITLE
fix(workflow): pin mise version

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Install Node and Prettier with mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          # renovate:general datasource=github-releases depName=jdx/mise
+          version: "v2026.9.2"
           install_args: node prettier
 
       - name: Check formatting


### PR DESCRIPTION
## What
- `renovate-version` を `2026.9.2` に固定
- Renovate による更新を設定
  
## Why
- mise 由来の不具合で CI が落ちた: https://github.com/traPtitech/manifest/actions/runs/34210172605/job/102010033590

## Verification
- https://github.com/traPtitech/manifest/actions/runs/34213524825/job/102019818557

## Summary by CodeRabbit

* **Chores**
  * フォーマット処理に使用する環境のバージョンを固定し、更新管理を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->