### PR TITLE
chore: 🤖 RenovateのPRをCodeRabbitのレビュー対象にする

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@ language: ja-JP
 reviews:
   auto_review:
     enabled: false
-    # レビュー対象の Renovate PR に付与するラベル。
+    # レビュー対象の Renovate PR に付与するラベル
     labels:
       - renovate-auto-review
     ignore_usernames: []

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+---
+language: ja-JP
+reviews:
+  auto_review:
+    enabled: true
+    # trap-renovate[bot] を含め、Bot の PR もレビューする。
+    ignore_usernames: []
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        Renovate が作成する依存関係更新 PR では、次の観点でレビューしてください。
+        - 更新前後のバージョンを特定し、その間の公式 release notes / changelog を確認する。
+        - breaking changes、非推奨化・削除された設定、必要な移行手順を確認する。
+        - 既存の Kubernetes マニフェスト、Helm values、CRD、関連コンポーネントとの compatibility を確認する。
+        - 設定変更、適用順序、データ移行など、更新に伴って必要になる対応を具体的に指摘する。
+        - 指摘には根拠となる公式情報の URL を添え、情報を取得できない場合や互換性を確認できない場合は明記する。

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@ language: ja-JP
 reviews:
   auto_review:
     enabled: false
-    # Renovate が付与するラベルで自動レビューを有効化する。
+    # Renovate の PR を自動レビュー
     labels:
       - renovate
     ignore_usernames: []

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,8 +2,10 @@
 language: ja-JP
 reviews:
   auto_review:
-    enabled: true
-    # trap-renovate[bot] を含め、Bot の PR もレビューする。
+    enabled: false
+    # Renovate が付与するラベルで自動レビューを有効化する。
+    labels:
+      - renovate
     ignore_usernames: []
   path_instructions:
     - path: "**/*"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,9 +3,9 @@ language: ja-JP
 reviews:
   auto_review:
     enabled: false
-    # Renovate の PR を自動レビュー
+    # レビュー対象の Renovate PR に付与するラベル。
     labels:
-      - renovate
+      - renovate-auto-review
     ignore_usernames: []
   path_instructions:
     - path: "**/*"

--- a/.github/renovate/labels.json5
+++ b/.github/renovate/labels.json5
@@ -1,7 +1,11 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  addLabels: ["renovate"],
   packageRules: [
+    {
+      // traPtitech のイメージ更新は自動レビューの対象外にする。
+      matchPackageNames: ["!ghcr.io/traptitech/**"],
+      addLabels: ["renovate"],
+    },
     {
       matchUpdateTypes: ["major"],
       labels: ["type/major"],

--- a/.github/renovate/labels.json5
+++ b/.github/renovate/labels.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
     {
-      // traPtitech のイメージ更新は自動レビューの対象外にする。
+      // traPtitech のイメージ更新は自動レビューの対象外にする
       matchPackageNames: ["!ghcr.io/traptitech/**"],
       addLabels: ["renovate-auto-review"],
     },

--- a/.github/renovate/labels.json5
+++ b/.github/renovate/labels.json5
@@ -1,5 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  addLabels: ["renovate"],
   packageRules: [
     {
       matchUpdateTypes: ["major"],

--- a/.github/renovate/labels.json5
+++ b/.github/renovate/labels.json5
@@ -4,7 +4,7 @@
     {
       // traPtitech のイメージ更新は自動レビューの対象外にする。
       matchPackageNames: ["!ghcr.io/traptitech/**"],
-      addLabels: ["renovate"],
+      addLabels: ["renovate-auto-review"],
     },
     {
       matchUpdateTypes: ["major"],


### PR DESCRIPTION
## Why

Renovate が作成する外部依存関係の更新 PR に AI レビューを付け、通常の PR と traPtitech のイメージ更新では自動レビューを無効にする。

Closes #1844

## What Changed

- `.coderabbit.yaml` を追加し、自動レビューを基本無効にして `renovate-auto-review` ラベル付き PR で有効化する。
- `ghcr.io/traptitech/**` 以外の依存関係更新に `renovate-auto-review` ラベルを追加し、既存の更新種別・データソース別ラベルと併用する。
- 依存関係更新では公式 release notes / changelog、破壊的変更、互換性、必要な移行対応を確認するよう指示する。

CodeRabbit [ラベルによる有効化](https://docs.coderabbit.ai/configuration/auto-review#labels)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * コードレビューの日本語設定を追加しました。
  * Renovateによるプルリクエストの自動レビュー設定を追加しました。
  * レビュー対象パスと依存関係更新時の確認項目を設定しました。
  * 一部のコンテナイメージを除き、Renovateの更新に自動レビュー用ラベルを付与するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->